### PR TITLE
Improve Wheel Building Process

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -69,7 +69,7 @@ jobs:
           submodules: recursive
       - uses: ilammy/msvc-dev-cmd@v1
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.3.1
+        uses: pypa/cibuildwheel@v2.4.0
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ option(COVERAGE "Configure for coverage report generation")
 option(BINDINGS "Configure for building Python bindings")
 option(DEPLOY "Configure for deployment")
 
+message("-- Generator is set to ${CMAKE_GENERATOR}")
+
 if (DEFINED ENV{DEPLOY})
     set(DEPLOY $ENV{DEPLOY} CACHE BOOL "Use deployment configuration from environment" FORCE)
     message(STATUS "Setting deployment configuration to '${DEPLOY}' from environment")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.14...3.22)
 
 project(ddsim
         LANGUAGES CXX
-        VERSION 1.11.2
+        VERSION 1.11.3
         DESCRIPTION "DDSIM - A JKQ quantum simulator based on decision diagrams"
         )
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,9 @@ include include/*
 include apps/*
 graft jkq/*
 graft mqt/*
+global-exclude __pycache__/
+global-exclude *.py[cod]
+global-exclude *.so
 
 # Include relevant files from other JKQ projects
 include extern/qfr/CMakeLists.txt
@@ -17,6 +20,9 @@ graft   extern/qfr/extern/dd_package/include
 graft   extern/qfr/extern/json
 prune   extern/qfr/extern/json/doc
 prune   extern/qfr/extern/json/test
+prune   extern/qfr/extern/json/benchmarks
+prune   extern/qfr/extern/json/third_party
+prune   extern/qfr/extern/json/include
 
 graft   extern/qfr/extern/pybind11
 prune   extern/qfr/extern/pybind11/docs
@@ -32,5 +38,9 @@ prune extern/taskflow/benchmarks
 prune extern/taskflow/doxygen
 prune extern/taskflow/3rd-party
 prune extern/taskflow/tfprof
+prune extern/taskflow/sandbox
+prune extern/taskflow/unittests
+prune extern/taskflow/examples
 
 graft extern/cxxopts
+prune extern/cxxopts/test

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -28,5 +28,9 @@ prune   extern/qfr/extern/pybind11_json/test
 graft extern/taskflow
 prune extern/taskflow/docs
 prune extern/taskflow/image
+prune extern/taskflow/benchmarks
+prune extern/taskflow/doxygen
+prune extern/taskflow/3rd-party
+prune extern/taskflow/tfprof
 
 graft extern/cxxopts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,15 @@
 [build-system]
-requires = ["setuptools", "ninja; sys_platform != 'win32'", "wheel", "cmake"]
+requires = [
+    "setuptools>=45",
+    "wheel>=0.37",
+    "ninja>=1.10; sys_platform != 'win32'",
+    "cmake>=3.14",
+]
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
 build = "cp3*"
-archs = ["auto64"]
+archs = "auto64"
 test-skip = "*_arm64 *-musllinux_x86_64 *_universal2:arm64"
 test-command = "python -c \"from mqt import ddsim\""
 test-requires = ["qiskit-terra"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
 build = "cp3*"
-skip = "*-win32 *-musllinux_i686 *-manylinux_i686 cp36-*"
+archs = ["auto64"]
+skip = "cp36-*"
 test-skip = "*_arm64 *-musllinux_x86_64 *_universal2:arm64"
 test-command = "python -c \"from mqt import ddsim\""
 test-requires = ["qiskit-terra"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
 build = "cp3*"
-skip = "*-win32 *-musllinux_i686 *-manylinux_i686"
+skip = "*-win32 *-musllinux_i686 *-manylinux_i686 cp36-*"
 test-skip = "*_arm64 *-musllinux_x86_64 *_universal2:arm64"
 test-command = "python -c \"from mqt import ddsim\""
 test-requires = ["qiskit-terra"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "cmake"]
+requires = ["setuptools", "ninja; sys_platform != 'win32'", "wheel", "cmake"]
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ build-backend = "setuptools.build_meta"
 [tool.cibuildwheel]
 build = "cp3*"
 archs = ["auto64"]
-skip = "cp36-*"
 test-skip = "*_arm64 *-musllinux_x86_64 *_universal2:arm64"
 test-command = "python -c \"from mqt import ddsim\""
 test-requires = ["qiskit-terra"]

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ class CMakeBuild(build_ext):
         cmake_args = ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
                       '-DPYTHON_EXECUTABLE=' + sys.executable,
                       '-DBINDINGS=ON']
-        print(self.compiler)
         if self.compiler.compiler_type != "msvc":
             # Using Ninja-build since it a) is available as a wheel and b)
             # multithreads automatically. MSVC would require all variables be

--- a/setup.py
+++ b/setup.py
@@ -74,14 +74,14 @@ with open(README_PATH, encoding="utf8") as readme_file:
 
 setup(
     name='mqt.ddsim',
-    version='1.11.2',
+    version='1.11.3',
     author='Stefan Hillmich',
     author_email='stefan.hillmich@jku.at',
     description='MQT DDSIM - A quantum simulator based on decision diagrams written in C++',
     long_description=README,
     long_description_content_type='text/markdown',
     license='MIT',
-    url='https://iic.jku.at/eda/research/quantum_simulation/',
+    url='https://www.cda.cit.tum.de/research/quantum_simulation/',
     ext_modules=[CMakeExtension('pyddsim', namespace='mqt.ddsim.')],
     cmdclass={"build_ext": CMakeBuild},
     zip_safe=False,
@@ -102,7 +102,7 @@ setup(
     project_urls={
         'Source': 'https://github.com/cda-tum/ddsim/',
         'Tracker': 'https://github.com/cda-tum/ddsim/issues',
-        'Research': 'https://iic.jku.at/eda/research/quantum_simulation/',
+        'Research': 'https://www.cda.cit.tum.de/research/quantum_simulation/',
     },
     extras_require={
         "tnflow": ["sparse", "opt-einsum", "quimb", "pandas", "numpy"]

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ setup(
     cmdclass={"build_ext": CMakeBuild},
     zip_safe=False,
     packages=find_namespace_packages(include=['mqt.*']),
+    python_requires=">=3.7"
     classifiers=[
         'Development Status :: 4 - Beta',
         'Programming Language :: Python :: 3',

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
     cmdclass={"build_ext": CMakeBuild},
     zip_safe=False,
     packages=find_namespace_packages(include=['mqt.*']),
-    python_requires=">=3.7"
+    python_requires=">=3.7",
     classifiers=[
         'Development Status :: 4 - Beta',
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
- Pruned directories from external submodules in MANIFEST.in to reduce size of sdist to below one megabyte.
- Use ninja as generator target on supported plattforms in setup.py to improve wheel build times
- Stop building wheels for python3.6 as it's eol since a couple months