### PR TITLE
🐛 Fix segfault for empty circuit in `PathSimulator`

### DIFF
--- a/src/PathSimulator.cpp
+++ b/src/PathSimulator.cpp
@@ -285,8 +285,10 @@ void PathSimulator::constructTaskGraph() {
     const auto& path  = simulationPath.components;
     const auto& steps = simulationPath.steps;
 
-    if (path.empty())
+    if (path.empty()) {
+        root_edge = dd->makeZeroState(qc->getNqubits());
         return;
+    }
 
     const std::size_t nleaves = qc->getNops() + 1;
 

--- a/test/test_path_sim.cpp
+++ b/test/test_path_sim.cpp
@@ -196,8 +196,8 @@ TEST(TaskBasedSimTest, EmptyCircuit) {
     PathSimulator tbs(std::move(qc));
 
     // simulate circuit
-    const auto shots = 1024U;
-    auto counts = tbs.Simulate(shots);
+    const auto shots  = 1024U;
+    auto       counts = tbs.Simulate(shots);
 
     for (const auto& [state, count]: counts) {
         EXPECT_EQ(state, "00");

--- a/test/test_path_sim.cpp
+++ b/test/test_path_sim.cpp
@@ -188,3 +188,20 @@ TEST(TaskBasedSimTest, GroverCircuitPairwiseGrouping) {
         std::cout << state << ": " << count << std::endl;
     }
 }
+
+TEST(TaskBasedSimTest, EmptyCircuit) {
+    auto qc = std::make_unique<qc::QuantumComputation>(2);
+
+    // construct simulator and generate bracketing contraction plan
+    PathSimulator tbs(std::move(qc));
+
+    // simulate circuit
+    const auto shots = 1024U;
+    auto counts = tbs.Simulate(shots);
+
+    for (const auto& [state, count]: counts) {
+        EXPECT_EQ(state, "00");
+        EXPECT_EQ(count, shots);
+        std::cout << state << ": " << count << std::endl;
+    }
+}


### PR DESCRIPTION
When given an empty circuit. The `PathSimulator` produced a segfault due to the `root_edge` not being intialized. This PR addresses this bug.