### PR TITLE
Fix missing macos-x64 builds

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -74,7 +74,8 @@ jobs:
         with:
           submodules: recursive
       - uses: ilammy/msvc-dev-cmd@v1
-      - if: ${{ matrix.config.arch }} == 'arm64'
+      - name: Set Architecture to arm64 if necessary
+        if: ${{ matrix.config.arch == 'arm64' }}
         run: echo "CIBW_ARCHS_MACOS=arm64" >> $GITHUB_ENV
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.11.3


### PR DESCRIPTION
The last release builds the arm64 wheels twice. 