### PR TITLE
✨ Expose Approximation Methods in Python

### DIFF
--- a/apps/simple.cpp
+++ b/apps/simple.cpp
@@ -40,7 +40,7 @@ int main(int argc, char** argv) {
         ("simulate_ghz", "simulate state preparation of GHZ state for given number of qubits", cxxopts::value<unsigned int>())
         ("step_fidelity", "target fidelity for each approximation run (>=1 = disable approximation)", cxxopts::value<double>()->default_value("1.0"))
         ("steps", "number of approximation steps", cxxopts::value<unsigned int>()->default_value("1"))
-        ("approx_when", "approximation method ('fidelity' (default) or 'memory'", cxxopts::value<std::string>()->default_value("fidelity"))
+        ("approx_when", "approximation strategy ('fidelity' (default) or 'memory'", cxxopts::value<std::string>()->default_value("fidelity"))
         ("approx_state", "do excessive approximation runs at the end of the simulation to see how the quantum state behaves")
         ("simulate_grover", "simulate Grover's search for given number of qubits with random oracle", cxxopts::value<unsigned int>())
         ("simulate_grover_emulated", "simulate Grover's search for given number of qubits with random oracle and emulation", cxxopts::value<unsigned int>())
@@ -66,18 +66,11 @@ int main(int argc, char** argv) {
 
     auto mode = HybridSchrodingerFeynmanSimulator<>::Mode::Amplitude;
 
-    ApproximationInfo::ApproximationMethod method;
-    if (vm["approx_when"].as<std::string>() == "fidelity") {
-        method = ApproximationInfo::FidelityDriven;
-    } else if (vm["approx_when"].as<std::string>() == "memory") {
-        method = ApproximationInfo::MemoryDriven;
-    } else {
-        throw std::runtime_error("Unknown approximation method '" + vm["approx_when"].as<std::string>() + "'.");
-    }
+    const auto strategy = ApproximationInfo::fromString(vm["approx_when"].as<std::string>());
 
     std::unique_ptr<qc::QuantumComputation>         quantumComputation;
     std::unique_ptr<Simulator<dd::DDPackageConfig>> ddsim{nullptr};
-    ApproximationInfo                               approximationInfo(stepFidelity, approxSteps, method);
+    ApproximationInfo                               approximationInfo(stepFidelity, approxSteps, strategy);
     const bool                                      verbose = vm.count("verbose") > 0;
 
     if (vm.count("simulate_file")) {

--- a/apps/simple.cpp
+++ b/apps/simple.cpp
@@ -58,32 +58,32 @@ int main(int argc, char** argv) {
         std::exit(0);
     }
 
-    const auto seed          = vm["seed"].as<unsigned long long>();
-    const auto shots         = vm["shots"].as<unsigned int>();
-    const auto nthreads      = vm["nthreads"].as<unsigned int>();
-    const auto approx_steps  = vm["steps"].as<unsigned int>();
-    const auto step_fidelity = vm["step_fidelity"].as<double>();
+    const auto seed         = vm["seed"].as<unsigned long long>();
+    const auto shots        = vm["shots"].as<unsigned int>();
+    const auto nthreads     = vm["nthreads"].as<unsigned int>();
+    const auto approxSteps  = vm["steps"].as<unsigned int>();
+    const auto stepFidelity = vm["step_fidelity"].as<double>();
 
     auto mode = HybridSchrodingerFeynmanSimulator<>::Mode::Amplitude;
 
-    ApproximationInfo::ApproximationWhen approx_when;
+    ApproximationInfo::ApproximationMethod method;
     if (vm["approx_when"].as<std::string>() == "fidelity") {
-        approx_when = ApproximationInfo::FidelityDriven;
+        method = ApproximationInfo::FidelityDriven;
     } else if (vm["approx_when"].as<std::string>() == "memory") {
-        approx_when = ApproximationInfo::MemoryDriven;
+        method = ApproximationInfo::MemoryDriven;
     } else {
         throw std::runtime_error("Unknown approximation method '" + vm["approx_when"].as<std::string>() + "'.");
     }
 
     std::unique_ptr<qc::QuantumComputation>         quantumComputation;
     std::unique_ptr<Simulator<dd::DDPackageConfig>> ddsim{nullptr};
-    ApproximationInfo                               approx_info(step_fidelity, approx_steps, approx_when);
+    ApproximationInfo                               approximationInfo(stepFidelity, approxSteps, method);
     const bool                                      verbose = vm.count("verbose") > 0;
 
     if (vm.count("simulate_file")) {
         const std::string fname = vm["simulate_file"].as<std::string>();
         quantumComputation      = std::make_unique<qc::QuantumComputation>(fname);
-        ddsim                   = std::make_unique<CircuitSimulator<dd::DDPackageConfig>>(std::move(quantumComputation), approx_info, seed);
+        ddsim                   = std::make_unique<CircuitSimulator<dd::DDPackageConfig>>(std::move(quantumComputation), approximationInfo, seed);
     } else if (vm.count("simulate_file_hybrid")) {
         const std::string fname = vm["simulate_file_hybrid"].as<std::string>();
         quantumComputation      = std::make_unique<qc::QuantumComputation>(fname);
@@ -96,14 +96,14 @@ int main(int argc, char** argv) {
             }
         }
         if (seed != 0) {
-            ddsim = std::make_unique<HybridSchrodingerFeynmanSimulator<dd::DDPackageConfig>>(std::move(quantumComputation), approx_info, seed, mode, nthreads);
+            ddsim = std::make_unique<HybridSchrodingerFeynmanSimulator<dd::DDPackageConfig>>(std::move(quantumComputation), approximationInfo, seed, mode, nthreads);
         } else {
             ddsim = std::make_unique<HybridSchrodingerFeynmanSimulator<dd::DDPackageConfig>>(std::move(quantumComputation), mode, nthreads);
         }
     } else if (vm.count("simulate_qft")) {
         const unsigned int n_qubits = vm["simulate_qft"].as<unsigned int>();
         quantumComputation          = std::make_unique<qc::QFT>(n_qubits);
-        ddsim                       = std::make_unique<CircuitSimulator<>>(std::move(quantumComputation), approx_info, seed);
+        ddsim                       = std::make_unique<CircuitSimulator<>>(std::move(quantumComputation), approximationInfo, seed);
     } else if (vm.count("simulate_fast_shor")) {
         const unsigned int composite_number = vm["simulate_fast_shor"].as<unsigned int>();
         const unsigned int coprime          = vm["simulate_fast_shor_coprime"].as<unsigned int>();
@@ -117,15 +117,15 @@ int main(int argc, char** argv) {
         const unsigned int coprime          = vm["simulate_shor_coprime"].as<unsigned int>();
         const bool         emulate          = vm.count("simulate_shor_no_emulation") == 0;
         if (seed == 0) {
-            ddsim = std::make_unique<ShorSimulator<dd::DDPackageConfig>>(composite_number, coprime, emulate, verbose, step_fidelity < 1);
+            ddsim = std::make_unique<ShorSimulator<dd::DDPackageConfig>>(composite_number, coprime, emulate, verbose, stepFidelity < 1);
         } else {
             ddsim = std::make_unique<ShorSimulator<dd::DDPackageConfig>>(composite_number, coprime, seed, emulate, verbose,
-                                                                         step_fidelity < 1);
+                                                                         stepFidelity < 1);
         }
     } else if (vm.count("simulate_grover")) {
         const unsigned int n_qubits = vm["simulate_grover"].as<unsigned int>();
         quantumComputation          = std::make_unique<qc::Grover>(n_qubits, seed);
-        ddsim                       = std::make_unique<CircuitSimulator<>>(std::move(quantumComputation), approx_info, seed);
+        ddsim                       = std::make_unique<CircuitSimulator<>>(std::move(quantumComputation), approximationInfo, seed);
     } else if (vm.count("simulate_grover_emulated")) {
         ddsim = std::make_unique<GroverSimulator<dd::DDPackageConfig>>(vm["simulate_grover_emulated"].as<unsigned int>(), seed);
     } else if (vm.count("simulate_grover_oracle_emulated")) {
@@ -133,7 +133,7 @@ int main(int argc, char** argv) {
     } else if (vm.count("simulate_ghz")) {
         const unsigned int n_qubits = vm["simulate_ghz"].as<unsigned int>();
         quantumComputation          = std::make_unique<qc::Entanglement>(n_qubits);
-        ddsim                       = std::make_unique<CircuitSimulator<>>(std::move(quantumComputation), approx_info, seed);
+        ddsim                       = std::make_unique<CircuitSimulator<>>(std::move(quantumComputation), approximationInfo, seed);
     } else {
         std::cerr << "Did not find anything to simulate. See help below.\n"
                   << options.help() << "\n";

--- a/include/CircuitSimulator.hpp
+++ b/include/CircuitSimulator.hpp
@@ -12,60 +12,61 @@
 #include <string>
 
 struct ApproximationInfo {
-    enum ApproximationWhen {
+    enum ApproximationMethod {
         FidelityDriven,
         MemoryDriven
     };
 
     /* Default to no approximation */
-    ApproximationInfo():
-        stepFidelity(1), stepNumber(1), approxWhen(ApproximationWhen::FidelityDriven) {}
+    ApproximationInfo() = default;
+    ApproximationInfo(const double stepFidelity_, const std::size_t stepNumber_, const ApproximationMethod method_):
+        stepFidelity(stepFidelity_), stepNumber(stepNumber_), method(method_) {}
 
-    ApproximationInfo(double stepFidelity_, unsigned int stepNumber_, ApproximationWhen approxWhen_):
-        stepFidelity(stepFidelity_), stepNumber(stepNumber_), approxWhen(approxWhen_) {}
+    static ApproximationMethod fromString(const std::string& str) {
+        if (str == "fidelity") {
+            return FidelityDriven;
+        } else if (str == "memory") {
+            return MemoryDriven;
+        } else {
+            throw std::runtime_error("Unknown approximation method '" + str + "'.");
+        }
+    }
 
-    friend std::istream& operator>>(std::istream& in, ApproximationWhen& when) {
+    friend std::istream& operator>>(std::istream& in, ApproximationMethod& method_) {
         std::string token;
         in >> token;
-
-        if (token == "fidelity") {
-            when = FidelityDriven;
-        } else if (token == "memory") {
-            when = MemoryDriven;
-        } else {
-            throw std::runtime_error("Unknown approximation method '" + token + "'.");
-        }
-
+        method_ = fromString(token);
         return in;
     }
 
-    const double            stepFidelity;
-    const unsigned int      stepNumber;
-    const ApproximationWhen approxWhen;
+    const double              stepFidelity = 1.;
+    const std::size_t         stepNumber   = 1;
+    const ApproximationMethod method       = FidelityDriven;
 };
 
 template<class Config = dd::DDPackageConfig>
 class CircuitSimulator: public Simulator<Config> {
 public:
     explicit CircuitSimulator(std::unique_ptr<qc::QuantumComputation>&& qc_):
-        qc(std::move(qc_)), approximationInfo(ApproximationInfo(1.0, 1, ApproximationInfo::FidelityDriven)) {
+        qc(std::move(qc_)) {
         Simulator<Config>::dd->resize(qc->getNqubits());
     }
 
     CircuitSimulator(std::unique_ptr<qc::QuantumComputation>&& qc_, const unsigned long long seed_):
-        Simulator<Config>(seed_),
-        qc(std::move(qc_)), approximationInfo(ApproximationInfo(1.0, 1, ApproximationInfo::FidelityDriven)) {
+        Simulator<Config>(seed_), qc(std::move(qc_)) {
         Simulator<Config>::dd->resize(qc->getNqubits());
     }
 
-    CircuitSimulator(std::unique_ptr<qc::QuantumComputation>&& qc_, const ApproximationInfo approximation_info):
-        qc(std::move(qc_)), approximationInfo(approximation_info) {
+    CircuitSimulator(std::unique_ptr<qc::QuantumComputation>&& qc_, const ApproximationInfo& approximationInfo_):
+        qc(std::move(qc_)), approximationInfo(approximationInfo_) {
         Simulator<Config>::dd->resize(qc->getNqubits());
     }
 
-    CircuitSimulator(std::unique_ptr<qc::QuantumComputation>&& qc_, const ApproximationInfo approximation_info, const unsigned long long seed_):
+    CircuitSimulator(std::unique_ptr<qc::QuantumComputation>&& qc_,
+                     const ApproximationInfo&                  approximationInfo_,
+                     const unsigned long long                  seed_):
         Simulator<Config>(seed_),
-        qc(std::move(qc_)), approximationInfo(approximation_info) {
+        qc(std::move(qc_)), approximationInfo(approximationInfo_) {
         Simulator<Config>::dd->resize(qc->getNqubits());
     }
 
@@ -90,7 +91,7 @@ protected:
     std::unique_ptr<qc::QuantumComputation> qc;
     std::size_t                             singleShots{0};
 
-    const ApproximationInfo approximationInfo;
+    const ApproximationInfo approximationInfo{};
     std::size_t             approximationRuns{0};
     long double             finalFidelity{1.0L};
 

--- a/include/CircuitSimulator.hpp
+++ b/include/CircuitSimulator.hpp
@@ -12,36 +12,36 @@
 #include <string>
 
 struct ApproximationInfo {
-    enum ApproximationMethod {
+    enum ApproximationStrategy {
         FidelityDriven,
         MemoryDriven
     };
 
     /* Default to no approximation */
     ApproximationInfo() = default;
-    ApproximationInfo(const double stepFidelity_, const std::size_t stepNumber_, const ApproximationMethod method_):
-        stepFidelity(stepFidelity_), stepNumber(stepNumber_), method(method_) {}
+    ApproximationInfo(const double stepFidelity_, const std::size_t stepNumber_, const ApproximationStrategy strategy_):
+        stepFidelity(stepFidelity_), stepNumber(stepNumber_), strategy(strategy_) {}
 
-    static ApproximationMethod fromString(const std::string& str) {
+    static ApproximationStrategy fromString(const std::string& str) {
         if (str == "fidelity") {
             return FidelityDriven;
         } else if (str == "memory") {
             return MemoryDriven;
         } else {
-            throw std::runtime_error("Unknown approximation method '" + str + "'.");
+            throw std::runtime_error("Unknown approximation strategy '" + str + "'.");
         }
     }
 
-    friend std::istream& operator>>(std::istream& in, ApproximationMethod& method_) {
+    friend std::istream& operator>>(std::istream& in, ApproximationStrategy& strategy_) {
         std::string token;
         in >> token;
-        method_ = fromString(token);
+        strategy_ = fromString(token);
         return in;
     }
 
-    const double              stepFidelity = 1.;
-    const std::size_t         stepNumber   = 1;
-    const ApproximationMethod method       = FidelityDriven;
+    const double                stepFidelity = 1.;
+    const std::size_t           stepNumber   = 1;
+    const ApproximationStrategy strategy     = FidelityDriven;
 };
 
 template<class Config = dd::DDPackageConfig>

--- a/include/HybridSchrodingerFeynmanSimulator.hpp
+++ b/include/HybridSchrodingerFeynmanSimulator.hpp
@@ -19,14 +19,28 @@ public:
         Amplitude
     };
 
-    explicit HybridSchrodingerFeynmanSimulator(std::unique_ptr<qc::QuantumComputation>&& qc_, Mode mode_ = Mode::Amplitude, const std::size_t nthreads_ = 2):
-        CircuitSimulator<Config>(std::move(qc_)), mode(mode_), nthreads(nthreads_) {
+    HybridSchrodingerFeynmanSimulator(std::unique_ptr<qc::QuantumComputation>&& qc_,
+                                      const ApproximationInfo&                  approxInfo_,
+                                      Mode                                      mode_     = Mode::Amplitude,
+                                      const std::size_t                         nthreads_ = 2):
+        CircuitSimulator<Config>(std::move(qc_), approxInfo_),
+        mode(mode_), nthreads(nthreads_) {
         // remove final measurements
         qc::CircuitOptimizer::removeFinalMeasurements(*(CircuitSimulator<Config>::qc));
     }
 
-    HybridSchrodingerFeynmanSimulator(std::unique_ptr<qc::QuantumComputation>&& qc_, const ApproximationInfo approx_info_, const unsigned long long seed_, Mode mode_ = Mode::Amplitude, const std::size_t nthreads_ = 2):
-        CircuitSimulator<Config>(std::move(qc_), approx_info_, seed_), mode(mode_), nthreads(nthreads_) {
+    explicit HybridSchrodingerFeynmanSimulator(std::unique_ptr<qc::QuantumComputation>&& qc_,
+                                               Mode                                      mode_     = Mode::Amplitude,
+                                               const std::size_t                         nthreads_ = 2):
+        HybridSchrodingerFeynmanSimulator(std::move(qc_), {}, mode_, nthreads_) {}
+
+    HybridSchrodingerFeynmanSimulator(std::unique_ptr<qc::QuantumComputation>&& qc_,
+                                      const ApproximationInfo&                  approxInfo_,
+                                      const unsigned long long                  seed_,
+                                      Mode                                      mode_     = Mode::Amplitude,
+                                      const std::size_t                         nthreads_ = 2):
+        CircuitSimulator<Config>(std::move(qc_), approxInfo_, seed_),
+        mode(mode_), nthreads(nthreads_) {
         // remove final measurements
         qc::CircuitOptimizer::removeFinalMeasurements(*(CircuitSimulator<Config>::qc));
     }

--- a/include/UnitarySimulator.hpp
+++ b/include/UnitarySimulator.hpp
@@ -17,14 +17,25 @@ public:
         Recursive
     };
 
-    explicit UnitarySimulator(std::unique_ptr<qc::QuantumComputation>&& qc_, Mode simMode = Mode::Recursive):
-        CircuitSimulator<Config>(std::move(qc_)), mode(simMode) {
+    UnitarySimulator(std::unique_ptr<qc::QuantumComputation>&& qc_,
+                     const ApproximationInfo&                  approximationInfo_,
+                     Mode                                      simMode = Mode::Recursive):
+        CircuitSimulator<Config>(std::move(qc_), approximationInfo_),
+        mode(simMode) {
         // remove final measurements
         qc::CircuitOptimizer::removeFinalMeasurements(*(CircuitSimulator<Config>::qc));
     }
 
-    UnitarySimulator(std::unique_ptr<qc::QuantumComputation>&& qc_, const ApproximationInfo approximation_info, const unsigned long long seed_, Mode simMode = Mode::Recursive):
-        CircuitSimulator<Config>(std::move(qc_), approximation_info, seed_), mode(simMode) {
+    explicit UnitarySimulator(std::unique_ptr<qc::QuantumComputation>&& qc_,
+                              Mode                                      simMode = Mode::Recursive):
+        UnitarySimulator(std::move(qc_), {}, simMode) {}
+
+    UnitarySimulator(std::unique_ptr<qc::QuantumComputation>&& qc_,
+                     const ApproximationInfo&                  approximationInfo_,
+                     const unsigned long long                  seed_,
+                     const Mode                                simMode = Mode::Recursive):
+        CircuitSimulator<Config>(std::move(qc_), approximationInfo_, seed_),
+        mode(simMode) {
         // remove final measurements
         qc::CircuitOptimizer::removeFinalMeasurements(*(CircuitSimulator<Config>::qc));
     }

--- a/mqt/ddsim/bindings.cpp
+++ b/mqt/ddsim/bindings.cpp
@@ -141,6 +141,7 @@ void dump_tensor_network(const py::object& circ, const std::string& filename) {
 PYBIND11_MODULE(pyddsim, m) {
     m.doc() = "Python interface for the MQT DDSIM quantum circuit simulator";
 
+    // Circuit Simulator
     py::class_<CircuitSimulator<>>(m, "CircuitSimulator")
             .def(py::init<>(&create_simulator<CircuitSimulator<>>),
                  "circ"_a,
@@ -154,6 +155,7 @@ PYBIND11_MODULE(pyddsim, m) {
             .def("statistics", &CircuitSimulator<>::AdditionalStatistics)
             .def("get_vector", &CircuitSimulator<>::getVectorComplex);
 
+    // Hybrid Schrödinger-Feynman Simulator
     py::enum_<HybridSchrodingerFeynmanSimulator<>::Mode>(m, "HybridMode")
             .value("DD", HybridSchrodingerFeynmanSimulator<>::Mode::DD)
             .value("amplitude", HybridSchrodingerFeynmanSimulator<>::Mode::Amplitude)
@@ -176,7 +178,7 @@ PYBIND11_MODULE(pyddsim, m) {
             .def("get_mode", &HybridSchrodingerFeynmanSimulator<>::getMode)
             .def("get_final_amplitudes", &HybridSchrodingerFeynmanSimulator<>::getFinalAmplitudes);
 
-    // TODO: Add new strategies here
+    // Path Simulator
     py::enum_<PathSimulator<>::Configuration::Mode>(m, "PathSimulatorMode")
             .value("sequential", PathSimulator<>::Configuration::Mode::Sequential)
             .value("pairwise_recursive", PathSimulator<>::Configuration::Mode::PairwiseRecursiveGrouping)
@@ -214,6 +216,7 @@ PYBIND11_MODULE(pyddsim, m) {
             .def("statistics", &CircuitSimulator<>::AdditionalStatistics)
             .def("get_vector", &CircuitSimulator<>::getVectorComplex);
 
+    // Unitary Simulator
     py::enum_<UnitarySimulator<>::Mode>(m, "ConstructionMode")
             .value("recursive", UnitarySimulator<>::Mode::Recursive)
             .value("sequential", UnitarySimulator<>::Mode::Sequential)
@@ -235,6 +238,7 @@ PYBIND11_MODULE(pyddsim, m) {
             .def("get_final_node_count", &UnitarySimulator<>::getFinalNodeCount)
             .def("get_max_node_count", &UnitarySimulator<>::getMaxNodeCount);
 
+    // Miscellaneous functions
     m.def("get_matrix", &getNumpyMatrix<>, "sim"_a, "mat"_a);
 
     m.def("dump_tensor_network", &dump_tensor_network, "dump a tensor network representation of the given circuit",

--- a/mqt/ddsim/bindings.cpp
+++ b/mqt/ddsim/bindings.cpp
@@ -47,11 +47,11 @@ template<class Simulator, typename... Args>
 std::unique_ptr<Simulator> create_simulator(const py::object&   circ,
                                             const double        stepFidelity,
                                             const unsigned int  stepNumber,
-                                            const std::string&  approximationMethod,
+                                            const std::string&  approximationStrategy,
                                             const long long int seed,
                                             Args&&... args) {
     auto       qc     = std::make_unique<qc::QuantumComputation>(importCircuit(circ));
-    const auto approx = ApproximationInfo{stepFidelity, stepNumber, ApproximationInfo::fromString(approximationMethod)};
+    const auto approx = ApproximationInfo{stepFidelity, stepNumber, ApproximationInfo::fromString(approximationStrategy)};
     if constexpr (std::is_same_v<Simulator, PathSimulator<>>) {
         return std::make_unique<Simulator>(std::move(qc),
                                            std::forward<Args>(args)...);
@@ -147,7 +147,7 @@ PYBIND11_MODULE(pyddsim, m) {
                  "circ"_a,
                  "approximation_step_fidelity"_a = 1.,
                  "approximation_steps"_a         = 1,
-                 "approximation_method"_a        = "fidelity",
+                 "approximation_strategy"_a      = "fidelity",
                  "seed"_a                        = -1)
             .def("get_number_of_qubits", &CircuitSimulator<>::getNumberOfQubits)
             .def("get_name", &CircuitSimulator<>::getName)
@@ -166,7 +166,7 @@ PYBIND11_MODULE(pyddsim, m) {
                  "circ"_a,
                  "approximation_step_fidelity"_a = 1.,
                  "approximation_steps"_a         = 1,
-                 "approximation_method"_a        = "fidelity",
+                 "approximation_strategy"_a      = "fidelity",
                  "seed"_a                        = -1,
                  "mode"_a                        = HybridSchrodingerFeynmanSimulator<>::Mode::Amplitude,
                  "nthreads"_a                    = 2)
@@ -227,7 +227,7 @@ PYBIND11_MODULE(pyddsim, m) {
                  "circ"_a,
                  "approximation_step_fidelity"_a = 1.,
                  "approximation_steps"_a         = 1,
-                 "approximation_method"_a        = "fidelity",
+                 "approximation_strategy"_a      = "fidelity",
                  "seed"_a                        = -1,
                  "mode"_a                        = UnitarySimulator<>::Mode::Recursive)
             .def("get_number_of_qubits", &CircuitSimulator<>::getNumberOfQubits)

--- a/mqt/ddsim/bindings.cpp
+++ b/mqt/ddsim/bindings.cpp
@@ -20,34 +20,49 @@
 namespace py = pybind11;
 using namespace pybind11::literals;
 
-template<class Simulator, typename... Args>
-std::unique_ptr<Simulator> create_simulator(const py::object& circ, const long long int seed, Args&&... args) {
-    py::object QuantumCircuit       = py::module::import("qiskit").attr("QuantumCircuit");
-    py::object pyQasmQobjExperiment = py::module::import("qiskit.qobj").attr("QasmQobjExperiment");
+static qc::QuantumComputation importCircuit(const py::object& circ) {
+    const py::object quantumCircuit =
+            py::module::import("qiskit").attr("QuantumCircuit");
+    const py::object pyQasmQobjExperiment =
+            py::module::import("qiskit.qobj").attr("QasmQobjExperiment");
 
-    std::unique_ptr<qc::QuantumComputation> qc = std::make_unique<qc::QuantumComputation>();
+    auto qc = qc::QuantumComputation();
 
     if (py::isinstance<py::str>(circ)) {
-        auto&& file1 = circ.cast<std::string>();
-        qc->import(file1);
-    } else if (py::isinstance(circ, QuantumCircuit)) {
-        qc::qiskit::QuantumCircuit::import(*qc, circ);
+        const auto file = circ.cast<std::string>();
+        qc.import(file);
+    } else if (py::isinstance(circ, quantumCircuit)) {
+        qc::qiskit::QuantumCircuit::import(qc, circ);
     } else if (py::isinstance(circ, pyQasmQobjExperiment)) {
-        qc::qiskit::QasmQobjExperiment::import(*qc, circ);
+        qc::qiskit::QasmQobjExperiment::import(qc, circ);
     } else {
-        throw std::runtime_error("PyObject is neither py::str, QuantumCircuit, nor QasmQobjExperiment");
+        throw std::runtime_error(
+                "PyObject is neither py::str, QuantumCircuit, nor QasmQobjExperiment");
     }
 
+    return qc;
+}
+
+template<class Simulator, typename... Args>
+std::unique_ptr<Simulator> create_simulator(const py::object&   circ,
+                                            const double        stepFidelity,
+                                            const unsigned int  stepNumber,
+                                            const std::string&  approximationMethod,
+                                            const long long int seed,
+                                            Args&&... args) {
+    auto       qc     = std::make_unique<qc::QuantumComputation>(importCircuit(circ));
+    const auto approx = ApproximationInfo{stepFidelity, stepNumber, ApproximationInfo::fromString(approximationMethod)};
     if constexpr (std::is_same_v<Simulator, PathSimulator<>>) {
         return std::make_unique<Simulator>(std::move(qc),
                                            std::forward<Args>(args)...);
     } else {
         if (seed < 0) {
             return std::make_unique<Simulator>(std::move(qc),
+                                               approx,
                                                std::forward<Args>(args)...);
         } else {
             return std::make_unique<Simulator>(std::move(qc),
-                                               ApproximationInfo{1, 1, ApproximationInfo::ApproximationWhen::FidelityDriven},
+                                               approx,
                                                seed,
                                                std::forward<Args>(args)...);
         }
@@ -56,7 +71,7 @@ std::unique_ptr<Simulator> create_simulator(const py::object& circ, const long l
 
 template<class Simulator, typename... Args>
 std::unique_ptr<Simulator> create_simulator_without_seed(const py::object& circ, Args&&... args) {
-    return create_simulator<Simulator>(circ, -1, std::forward<Args>(args)...);
+    return create_simulator<Simulator>(circ, 1., 1, "fidelity", -1, std::forward<Args>(args)...);
 }
 
 void getNumpyMatrixRec(const qc::MatrixDD& e, const std::complex<dd::fp>& amp, std::size_t i, std::size_t j, std::size_t dim, std::complex<dd::fp>* mat) {
@@ -127,8 +142,12 @@ PYBIND11_MODULE(pyddsim, m) {
     m.doc() = "Python interface for the MQT DDSIM quantum circuit simulator";
 
     py::class_<CircuitSimulator<>>(m, "CircuitSimulator")
-            .def(py::init<>(&create_simulator<CircuitSimulator<>>), "circ"_a, "seed"_a)
-            .def(py::init<>(&create_simulator_without_seed<CircuitSimulator<>>), "circ"_a)
+            .def(py::init<>(&create_simulator<CircuitSimulator<>>),
+                 "circ"_a,
+                 "approximation_step_fidelity"_a = 1.,
+                 "approximation_steps"_a         = 1,
+                 "approximation_method"_a        = "fidelity",
+                 "seed"_a                        = -1)
             .def("get_number_of_qubits", &CircuitSimulator<>::getNumberOfQubits)
             .def("get_name", &CircuitSimulator<>::getName)
             .def("simulate", &CircuitSimulator<>::Simulate, "shots"_a)
@@ -142,9 +161,13 @@ PYBIND11_MODULE(pyddsim, m) {
 
     py::class_<HybridSchrodingerFeynmanSimulator<>>(m, "HybridCircuitSimulator")
             .def(py::init<>(&create_simulator<HybridSchrodingerFeynmanSimulator<>, HybridSchrodingerFeynmanSimulator<>::Mode&, const std::size_t&>),
-                 "circ"_a, "seed"_a, "mode"_a = HybridSchrodingerFeynmanSimulator<>::Mode::Amplitude, "nthreads"_a = 2)
-            .def(py::init<>(&create_simulator_without_seed<HybridSchrodingerFeynmanSimulator<>, HybridSchrodingerFeynmanSimulator<>::Mode&, const std::size_t&>),
-                 "circ"_a, "mode"_a = HybridSchrodingerFeynmanSimulator<>::Mode::Amplitude, "nthreads"_a = 2)
+                 "circ"_a,
+                 "approximation_step_fidelity"_a = 1.,
+                 "approximation_steps"_a         = 1,
+                 "approximation_method"_a        = "fidelity",
+                 "seed"_a                        = -1,
+                 "mode"_a                        = HybridSchrodingerFeynmanSimulator<>::Mode::Amplitude,
+                 "nthreads"_a                    = 2)
             .def("get_number_of_qubits", &CircuitSimulator<>::getNumberOfQubits)
             .def("get_name", &CircuitSimulator<>::getName)
             .def("simulate", &HybridSchrodingerFeynmanSimulator<>::Simulate, "shots"_a)
@@ -198,9 +221,12 @@ PYBIND11_MODULE(pyddsim, m) {
 
     py::class_<UnitarySimulator<>>(m, "UnitarySimulator")
             .def(py::init<>(&create_simulator<UnitarySimulator<>, UnitarySimulator<>::Mode&>),
-                 "circ"_a, "seed"_a, "mode"_a = UnitarySimulator<>::Mode::Recursive)
-            .def(py::init<>(&create_simulator_without_seed<UnitarySimulator<>, UnitarySimulator<>::Mode&>),
-                 "circ"_a, "mode"_a = UnitarySimulator<>::Mode::Recursive)
+                 "circ"_a,
+                 "approximation_step_fidelity"_a = 1.,
+                 "approximation_steps"_a         = 1,
+                 "approximation_method"_a        = "fidelity",
+                 "seed"_a                        = -1,
+                 "mode"_a                        = UnitarySimulator<>::Mode::Recursive)
             .def("get_number_of_qubits", &CircuitSimulator<>::getNumberOfQubits)
             .def("get_name", &CircuitSimulator<>::getName)
             .def("construct", &UnitarySimulator<>::Construct)

--- a/mqt/ddsim/hybridqasmsimulator.py
+++ b/mqt/ddsim/hybridqasmsimulator.py
@@ -125,7 +125,7 @@ class HybridQasmSimulator(BackendV1):
         else:
             raise DDSIMError('Simulation mode', mode, 'not supported by MQT hybrid simulator. Available modes are \'amplitude\' and \'dd\'')
 
-        sim = ddsim.HybridCircuitSimulator(qobj_experiment, seed, hybrid_mode, nthreads)
+        sim = ddsim.HybridCircuitSimulator(qobj_experiment, seed=seed, mode=hybrid_mode, nthreads=nthreads)
 
         shots = options.get('shots', 1024)
         if self.SHOW_STATE_VECTOR and shots > 0:

--- a/mqt/ddsim/qasmsimulator.py
+++ b/mqt/ddsim/qasmsimulator.py
@@ -106,13 +106,13 @@ class QasmSimulator(BackendV1):
         start_time = time.time()
         approximation_step_fidelity = options.get('approximation_step_fidelity', 1.0)
         approximation_steps = options.get('approximation_steps', 1)
-        approximation_method = options.get('approximation_method', 'fidelity')
+        approximation_strategy = options.get('approximation_strategy', 'fidelity')
         seed = options.get('seed', -1)
 
         sim = ddsim.CircuitSimulator(qobj_experiment,
                                      approximation_step_fidelity=approximation_step_fidelity,
                                      approximation_steps=approximation_steps,
-                                     approximation_method=approximation_method,
+                                     approximation_strategy=approximation_strategy,
                                      seed=seed)
         counts = sim.simulate(options.get('shots', 1024))
         end_time = time.time()

--- a/mqt/ddsim/qasmsimulator.py
+++ b/mqt/ddsim/qasmsimulator.py
@@ -104,7 +104,16 @@ class QasmSimulator(BackendV1):
 
     def run_experiment(self, qobj_experiment: QasmQobjExperiment, **options):
         start_time = time.time()
-        sim = ddsim.CircuitSimulator(qobj_experiment, options.get('seed', -1))
+        approximation_step_fidelity = options.get('approximation_step_fidelity', 1.0)
+        approximation_steps = options.get('approximation_steps', 1)
+        approximation_method = options.get('approximation_method', 'fidelity')
+        seed = options.get('seed', -1)
+
+        sim = ddsim.CircuitSimulator(qobj_experiment,
+                                     approximation_step_fidelity=approximation_step_fidelity,
+                                     approximation_steps=approximation_steps,
+                                     approximation_method=approximation_method,
+                                     seed=seed)
         counts = sim.simulate(options.get('shots', 1024))
         end_time = time.time()
         counts_hex = {hex(int(result, 2)): count for result, count in counts.items()}

--- a/mqt/ddsim/unitarysimulator.py
+++ b/mqt/ddsim/unitarysimulator.py
@@ -114,7 +114,7 @@ class UnitarySimulator(BackendV1):
         else:
             raise DDSIMError('Construction mode', mode, 'not supported by DDSIM unitary simulator. Available modes are \'recursive\' and \'sequential\'')
 
-        sim = ddsim.UnitarySimulator(qobj_experiment, seed, construction_mode)
+        sim = ddsim.UnitarySimulator(qobj_experiment, seed=seed, mode=construction_mode)
         sim.construct()
         # Add extract resulting matrix from final DD and write data
         unitary = np.zeros((2 ** qobj_experiment.header.n_qubits, 2 ** qobj_experiment.header.n_qubits), dtype=complex)

--- a/src/CircuitSimulator.cpp
+++ b/src/CircuitSimulator.cpp
@@ -154,7 +154,7 @@ std::map<std::size_t, bool> CircuitSimulator<Config>::singleShot(const bool igno
             Simulator<Config>::rootEdge = tmp;
 
             if (approximationInfo.stepNumber > 0 && approximationInfo.stepFidelity < 1.0) {
-                if (approximationInfo.method == ApproximationInfo::FidelityDriven && (opNum + 1) % approxMod == 0 &&
+                if (approximationInfo.strategy == ApproximationInfo::FidelityDriven && (opNum + 1) % approxMod == 0 &&
                     approximationRuns < approximationInfo.stepNumber) {
                     [[maybe_unused]] const unsigned int size_before = Simulator<Config>::dd->size(Simulator<Config>::rootEdge);
                     const auto                          apFid       = Simulator<Config>::ApproximateByFidelity(approximationInfo.stepFidelity, false, true);
@@ -167,7 +167,7 @@ std::map<std::size_t, bool> CircuitSimulator<Config>::singleShot(const bool igno
                               << "; global fidelity=" << final_fidelity
                               << "; #runs=" << approximation_runs
                               << "\n";//*/
-                } else if (approximationInfo.method == ApproximationInfo::MemoryDriven) {
+                } else if (approximationInfo.strategy == ApproximationInfo::MemoryDriven) {
                     [[maybe_unused]] const unsigned int size_before = Simulator<Config>::dd->size(Simulator<Config>::rootEdge);
                     if (Simulator<Config>::dd->template getUniqueTable<dd::vNode>().possiblyNeedsCollection()) {
                         const auto apFid = Simulator<Config>::ApproximateByFidelity(approximationInfo.stepFidelity, false, true);

--- a/src/CircuitSimulator.cpp
+++ b/src/CircuitSimulator.cpp
@@ -154,7 +154,7 @@ std::map<std::size_t, bool> CircuitSimulator<Config>::singleShot(const bool igno
             Simulator<Config>::rootEdge = tmp;
 
             if (approximationInfo.stepNumber > 0 && approximationInfo.stepFidelity < 1.0) {
-                if (approximationInfo.approxWhen == ApproximationInfo::FidelityDriven && (opNum + 1) % approxMod == 0 &&
+                if (approximationInfo.method == ApproximationInfo::FidelityDriven && (opNum + 1) % approxMod == 0 &&
                     approximationRuns < approximationInfo.stepNumber) {
                     [[maybe_unused]] const unsigned int size_before = Simulator<Config>::dd->size(Simulator<Config>::rootEdge);
                     const auto                          apFid       = Simulator<Config>::ApproximateByFidelity(approximationInfo.stepFidelity, false, true);
@@ -167,7 +167,7 @@ std::map<std::size_t, bool> CircuitSimulator<Config>::singleShot(const bool igno
                               << "; global fidelity=" << final_fidelity
                               << "; #runs=" << approximation_runs
                               << "\n";//*/
-                } else if (approximationInfo.approxWhen == ApproximationInfo::MemoryDriven) {
+                } else if (approximationInfo.method == ApproximationInfo::MemoryDriven) {
                     [[maybe_unused]] const unsigned int size_before = Simulator<Config>::dd->size(Simulator<Config>::rootEdge);
                     if (Simulator<Config>::dd->template getUniqueTable<dd::vNode>().possiblyNeedsCollection()) {
                         const auto apFid = Simulator<Config>::ApproximateByFidelity(approximationInfo.stepFidelity, false, true);

--- a/src/Simulator.cpp
+++ b/src/Simulator.cpp
@@ -178,9 +178,16 @@ double Simulator<Config>::ApproximateByFidelity(std::unique_ptr<dd::Package<Conf
                 break;
             }
         }
-        if (!allLevels && remove * i > max_remove) {
-            max_remove      = remove * i;
-            nodes_to_remove = tmp;
+        if (!allLevels) {
+            if (i == 0) {
+                if (remove > max_remove) {
+                    max_remove      = remove;
+                    nodes_to_remove = tmp;
+                }
+            } else if (remove * i > max_remove) {
+                max_remove      = remove * i;
+                nodes_to_remove = tmp;
+            }
         }
     }
 

--- a/test/python/simulator/test_standalone_simulator.py
+++ b/test/python/simulator/test_standalone_simulator.py
@@ -24,7 +24,7 @@ class MQTStandaloneSimulatorTests(unittest.TestCase):
         circ.cx(0, 1)
         circ.cx(0, 2)
 
-        sim = ddsim.CircuitSimulator(circ, 1337)
+        sim = ddsim.CircuitSimulator(circ, seed=1337)
         result = sim.simulate(1000)
         self.assertEqual(len(result.keys()), 2)
         self.assertIn('000', result.keys())

--- a/test/python/simulator/test_standalone_simulator.py
+++ b/test/python/simulator/test_standalone_simulator.py
@@ -29,3 +29,20 @@ class MQTStandaloneSimulatorTests(unittest.TestCase):
         self.assertEqual(len(result.keys()), 2)
         self.assertIn('000', result.keys())
         self.assertIn('111', result.keys())
+
+    def test_standalone_simple_approximation(self):
+        import numpy as np
+
+        # creates a state with <2% probability of measuring |1x>
+        circ = QuantumCircuit(2)
+        circ.h(0)
+        circ.cry(np.pi / 8, 0, 1)
+
+        # create a simulator that approximates once and by at most 2%
+        sim = ddsim.CircuitSimulator(circ, approximation_step_fidelity=0.98, approximation_steps=2)
+        result = sim.simulate(4096)
+
+        # the result should always be 0
+        self.assertEqual(len(result.keys()), 2)
+        self.assertIn('00', result.keys())
+        self.assertIn('01', result.keys())

--- a/test/python/unitarysimulator/test_standalone_unitary_simulator.py
+++ b/test/python/unitarysimulator/test_standalone_unitary_simulator.py
@@ -24,7 +24,7 @@ class MQTStandaloneUnitarySimulatorTests(unittest.TestCase):
         self.assertEqual(np.count_nonzero(self.unitary), 16)
 
     def test_standalone_sequential_mode_with_seed(self):
-        sim = ddsim.UnitarySimulator(self.circuit, 1337, mode=ddsim.ConstructionMode.sequential)
+        sim = ddsim.UnitarySimulator(self.circuit, seed=1337, mode=ddsim.ConstructionMode.sequential)
         sim.construct()
 
         ddsim.get_matrix(sim, self.unitary)
@@ -40,7 +40,7 @@ class MQTStandaloneUnitarySimulatorTests(unittest.TestCase):
         self.assertEqual(np.count_nonzero(self.unitary), 16)
 
     def test_standalone_recursive_mode_with_seed(self):
-        sim = ddsim.UnitarySimulator(self.circuit, 1337, mode=ddsim.ConstructionMode.recursive)
+        sim = ddsim.UnitarySimulator(self.circuit, seed=1337, mode=ddsim.ConstructionMode.recursive)
         sim.construct()
 
         ddsim.get_matrix(sim, self.unitary)

--- a/test/test_circuit_sim.cpp
+++ b/test/test_circuit_sim.cpp
@@ -244,3 +244,17 @@ TEST(CircuitSimTest, TestingProperties) {
     EXPECT_EQ(ddsim.getMatrixActiveNodeCount(), 0);
     EXPECT_EQ(ddsim.countNodesFromRoot(), 7);
 }
+
+TEST(CircuitSimTest, ApproximationTest) {
+    // the following creates a state where the first qubit has a <2% probability of being 1
+    auto qc = std::make_unique<qc::QuantumComputation>(2);
+    qc->h(0);
+    qc->ry(1, qc::Control{0}, qc::PI / 8);
+
+    // approximating the state with fidelity 0.98 should allow to eliminate the 1-successor of the first qubit
+    CircuitSimulator ddsim(std::move(qc), ApproximationInfo(0.98, 2, ApproximationInfo::FidelityDriven));
+    ddsim.Simulate(4096);
+    const auto vec = ddsim.getVectorComplex();
+    EXPECT_EQ(abs(vec[2]), 0);
+    EXPECT_EQ(abs(vec[3]), 0);
+}

--- a/test/test_circuit_sim.cpp
+++ b/test/test_circuit_sim.cpp
@@ -165,8 +165,8 @@ TEST(CircuitSimTest, ApproximateByFidelity) {
 
     double resulting_fidelity = ddsim.ApproximateByFidelity(0.3, false, true, true);
 
-    ASSERT_EQ(ddsim.getActiveNodeCount(), 4);
-    ASSERT_DOUBLE_EQ(resulting_fidelity, 0.75); //equal up to 4 ULP
+    ASSERT_EQ(ddsim.getActiveNodeCount(), 3);
+    ASSERT_DOUBLE_EQ(resulting_fidelity, 0.5); //equal up to 4 ULP
 }
 
 TEST(CircuitSimTest, ApproximateBySampling) {
@@ -206,8 +206,8 @@ TEST(CircuitSimTest, ApproximationByFidelityInSimulator) {
     CircuitSimulator ddsim(std::move(quantumComputation), ApproximationInfo(0.3, 1, ApproximationInfo::FidelityDriven));
     ddsim.Simulate(1);
 
-    ASSERT_EQ(ddsim.getActiveNodeCount(), 4);
-    ASSERT_LE(std::stod(ddsim.AdditionalStatistics()["final_fidelity"]), 0.75); // the least contributing path has .25
+    ASSERT_EQ(ddsim.getActiveNodeCount(), 3);
+    ASSERT_DOUBLE_EQ(std::stod(ddsim.AdditionalStatistics()["final_fidelity"]), 0.5);
 }
 
 TEST(CircuitSimTest, GRCS4x4Test) {

--- a/test/test_stoch_noise_sim.cpp
+++ b/test/test_stoch_noise_sim.cpp
@@ -162,8 +162,8 @@ TEST(StochNoiseSimTest, ApproximateByFidelity) {
 
     double resulting_fidelity = ddsim.ApproximateByFidelity(0.3, false, true);
 
-    ASSERT_EQ(ddsim.getActiveNodeCount(), 4);
-    ASSERT_DOUBLE_EQ(resulting_fidelity, 0.75); //equal up to 4 ULP
+    ASSERT_EQ(ddsim.getActiveNodeCount(), 3);
+    ASSERT_DOUBLE_EQ(resulting_fidelity, 0.5); //equal up to 4 ULP
 }
 
 TEST(StochNoiseSimTest, ApproximateBySampling) {


### PR DESCRIPTION
This PR adds the necessary changes to expose the existing approximation functionality to Python.
Changes are really minor; mostly unification of the simulator constructors.

While writing tests, I even found and subsequently fixed a bug in the implementation that prevented nodes at level 0 from being collected.