### PR TITLE
✨ Expose tolerance and node counts to Python

### DIFF
--- a/include/Simulator.hpp
+++ b/include/Simulator.hpp
@@ -105,6 +105,9 @@ public:
     void setTolerance(const dd::fp tolerance) {
         dd->cn.setTolerance(tolerance);
     }
+    [[nodiscard]] dd::fp getTolerance() const {
+        return dd->cn.complexTable.tolerance();
+    }
 
     [[nodiscard]] std::vector<std::priority_queue<std::pair<double, dd::vNode*>, std::vector<std::pair<double, dd::vNode*>>>> getNodeContributions(const dd::vEdge& edge) const;
 

--- a/include/Simulator.hpp
+++ b/include/Simulator.hpp
@@ -102,6 +102,10 @@ public:
         return binary;
     }
 
+    void setTolerance(const dd::fp tolerance) {
+        dd->cn.setTolerance(tolerance);
+    }
+
     [[nodiscard]] std::vector<std::priority_queue<std::pair<double, dd::vNode*>, std::vector<std::pair<double, dd::vNode*>>>> getNodeContributions(const dd::vEdge& edge) const;
 
     double approximateByFidelity(std::unique_ptr<dd::Package<Config>>& localDD, dd::vEdge& edge, double targetFidelity, bool allLevels, bool actuallyRemoveNodes, bool verbose = false);

--- a/mqt/ddsim/bindings.cpp
+++ b/mqt/ddsim/bindings.cpp
@@ -44,12 +44,12 @@ static qc::QuantumComputation importCircuit(const py::object& circ) {
 }
 
 template<class Simulator, typename... Args>
-std::unique_ptr<Simulator> createSimulator(const py::object&  circ,
-                                           const double       stepFidelity,
-                                           const unsigned int stepNumber,
-                                           const std::string& approximationStrategy,
-                                           const std::int64_t seed,
-                                           Args&&... args) {
+std::unique_ptr<Simulator> constructSimulator(const py::object&  circ,
+                                              const double       stepFidelity,
+                                              const unsigned int stepNumber,
+                                              const std::string& approximationStrategy,
+                                              const std::int64_t seed,
+                                              Args&&... args) {
     auto       qc     = std::make_unique<qc::QuantumComputation>(importCircuit(circ));
     const auto approx = ApproximationInfo{stepFidelity, stepNumber, ApproximationInfo::fromString(approximationStrategy)};
     if constexpr (std::is_same_v<Simulator, PathSimulator<>>) {
@@ -69,8 +69,8 @@ std::unique_ptr<Simulator> createSimulator(const py::object&  circ,
 }
 
 template<class Simulator, typename... Args>
-std::unique_ptr<Simulator> createSimulatorWithoutSeed(const py::object& circ, Args&&... args) {
-    return createSimulator<Simulator>(circ, 1., 1, "fidelity", -1, std::forward<Args>(args)...);
+std::unique_ptr<Simulator> constructSimulatorWithoutSeed(const py::object& circ, Args&&... args) {
+    return constructSimulator<Simulator>(circ, 1., 1, "fidelity", -1, std::forward<Args>(args)...);
 }
 
 void getNumpyMatrixRec(const qc::MatrixDD& e, const std::complex<dd::fp>& amp, std::size_t i, std::size_t j, std::size_t dim, std::complex<dd::fp>* mat) {
@@ -141,38 +141,39 @@ void dumpTensorNetwork(const py::object& circ, const std::string& filename) {
     qc->dump(ofs, qc::Format::Tensor);
 }
 
-template<class Simulator>
-void addCommonSimulatorMethods(py::class_<Simulator>& cls) {
-    cls.def("get_number_of_qubits", &Simulator::getNumberOfQubits, "Get the number of qubits")
-            .def("get_name", &Simulator::getName, "Get the name of the simulator")
-            .def("statistics", &Simulator::additionalStatistics, "Get additional statistics provided by the simulator")
-            .def("get_active_vector_node_count", &Simulator::getActiveNodeCount, "Get the number of active vector nodes, i.e., the number of vector DD nodes in the unique table with a non-zero reference count.")
-            .def("get_active_matrix_node_count", &Simulator::getMatrixActiveNodeCount, "Get the number of active matrix nodes, i.e., the number of matrix DD nodes in the unique table with a non-zero reference count.")
-            .def("get_max_vector_node_count", &Simulator::getMaxNodeCount, "Get the maximum number of (active) vector nodes, i.e., the maximum number of vector DD nodes in the unique table at any point during the simulation.")
-            .def("get_max_matrix_node_count", &Simulator::getMaxMatrixNodeCount, "Get the maximum number of (active) matrix nodes, i.e., the maximum number of matrix DD nodes in the unique table at any point during the simulation.")
-            .def("get_tolerance", &Simulator::getTolerance, "Get the tolerance for the DD package.")
-            .def("set_tolerance", &Simulator::setTolerance, "tol"_a, "Set the tolerance for the DD package.");
+template<class Sim>
+py::class_<Sim> createSimulator(py::module_ m, const std::string& name) {
+    auto sim = py::class_<Sim>(m, name.c_str());
+    sim.def("get_number_of_qubits", &Sim::getNumberOfQubits, "Get the number of qubits")
+            .def("get_name", &Sim::getName, "Get the name of the simulator")
+            .def("statistics", &Sim::additionalStatistics, "Get additional statistics provided by the simulator")
+            .def("get_active_vector_node_count", &Sim::getActiveNodeCount, "Get the number of active vector nodes, i.e., the number of vector DD nodes in the unique table with a non-zero reference count.")
+            .def("get_active_matrix_node_count", &Sim::getMatrixActiveNodeCount, "Get the number of active matrix nodes, i.e., the number of matrix DD nodes in the unique table with a non-zero reference count.")
+            .def("get_max_vector_node_count", &Sim::getMaxNodeCount, "Get the maximum number of (active) vector nodes, i.e., the maximum number of vector DD nodes in the unique table at any point during the simulation.")
+            .def("get_max_matrix_node_count", &Sim::getMaxMatrixNodeCount, "Get the maximum number of (active) matrix nodes, i.e., the maximum number of matrix DD nodes in the unique table at any point during the simulation.")
+            .def("get_tolerance", &Sim::getTolerance, "Get the tolerance for the DD package.")
+            .def("set_tolerance", &Sim::setTolerance, "tol"_a, "Set the tolerance for the DD package.");
 
-    if constexpr (std::is_same_v<Simulator, UnitarySimulator<>>) {
-        cls.def("construct", &Simulator::construct, "Construct the DD representing the unitary matrix of the circuit.");
+    if constexpr (std::is_same_v<Sim, UnitarySimulator<>>) {
+        sim.def("construct", &Sim::construct, "Construct the DD representing the unitary matrix of the circuit.");
     } else {
-        cls.def("simulate", &Simulator::simulate, "shots"_a, "Simulate the circuit and return the result as a dictionary of counts.");
-        cls.def("get_vector", &Simulator::getVectorComplex, "Get the state vector resulting from the simulation.");
+        sim.def("simulate", &Sim::simulate, "shots"_a, "Simulate the circuit and return the result as a dictionary of counts.");
+        sim.def("get_vector", &Sim::getVectorComplex, "Get the state vector resulting from the simulation.");
     }
+    return sim;
 }
 
 PYBIND11_MODULE(pyddsim, m) {
     m.doc() = "Python interface for the MQT DDSIM quantum circuit simulator";
 
     // Circuit Simulator
-    auto circuitSimulator = py::class_<CircuitSimulator<>>(m, "CircuitSimulator");
-    circuitSimulator.def(py::init<>(&createSimulator<CircuitSimulator<>>),
+    auto circuitSimulator = createSimulator<CircuitSimulator<>>(m, "CircuitSimulator");
+    circuitSimulator.def(py::init<>(&constructSimulator<CircuitSimulator<>>),
                          "circ"_a,
                          "approximation_step_fidelity"_a = 1.,
                          "approximation_steps"_a         = 1,
                          "approximation_strategy"_a      = "fidelity",
                          "seed"_a                        = -1);
-    addCommonSimulatorMethods(circuitSimulator);
 
     // Hybrid Schrödinger-Feynman Simulator
     py::enum_<HybridSchrodingerFeynmanSimulator<>::Mode>(m, "HybridMode")
@@ -180,8 +181,8 @@ PYBIND11_MODULE(pyddsim, m) {
             .value("amplitude", HybridSchrodingerFeynmanSimulator<>::Mode::Amplitude)
             .export_values();
 
-    auto hsfSimulator = py::class_<HybridSchrodingerFeynmanSimulator<>>(m, "HybridCircuitSimulator");
-    hsfSimulator.def(py::init<>(&createSimulator<HybridSchrodingerFeynmanSimulator<>, HybridSchrodingerFeynmanSimulator<>::Mode&, const std::size_t&>),
+    auto hsfSimulator = createSimulator<HybridSchrodingerFeynmanSimulator<>>(m, "HybridCircuitSimulator");
+    hsfSimulator.def(py::init<>(&constructSimulator<HybridSchrodingerFeynmanSimulator<>, HybridSchrodingerFeynmanSimulator<>::Mode&, const std::size_t&>),
                      "circ"_a,
                      "approximation_step_fidelity"_a = 1.,
                      "approximation_steps"_a         = 1,
@@ -191,7 +192,6 @@ PYBIND11_MODULE(pyddsim, m) {
                      "nthreads"_a                    = 2)
             .def("get_mode", &HybridSchrodingerFeynmanSimulator<>::getMode)
             .def("get_final_amplitudes", &HybridSchrodingerFeynmanSimulator<>::getFinalAmplitudes);
-    addCommonSimulatorMethods(hsfSimulator);
 
     // Path Simulator
     py::enum_<PathSimulator<>::Configuration::Mode>(m, "PathSimulatorMode")
@@ -219,13 +219,12 @@ PYBIND11_MODULE(pyddsim, m) {
             .def("json", &PathSimulator<>::Configuration::json)
             .def("__repr__", &PathSimulator<>::Configuration::toString);
 
-    auto pathSimulator = py::class_<PathSimulator<>>(m, "PathCircuitSimulator");
-    pathSimulator.def(py::init<>(&createSimulatorWithoutSeed<PathSimulator<>, PathSimulator<>::Configuration&>),
+    auto pathSimulator = createSimulator<PathSimulator<>>(m, "PathCircuitSimulator");
+    pathSimulator.def(py::init<>(&constructSimulatorWithoutSeed<PathSimulator<>, PathSimulator<>::Configuration&>),
                       "circ"_a, "config"_a = PathSimulator<>::Configuration())
-            .def(py::init<>(&createSimulatorWithoutSeed<PathSimulator<>, PathSimulator<>::Configuration::Mode&, const std::size_t&, const std::size_t&, const std::list<std::size_t>&, const std::size_t&>),
+            .def(py::init<>(&constructSimulatorWithoutSeed<PathSimulator<>, PathSimulator<>::Configuration::Mode&, const std::size_t&, const std::size_t&, const std::list<std::size_t>&, const std::size_t&>),
                  "circ"_a, "mode"_a = PathSimulator<>::Configuration::Mode::Sequential, "bracket_size"_a = 2, "starting_point"_a = 0, "gate_cost"_a = std::list<std::size_t>{}, "seed"_a = 0)
             .def("set_simulation_path", py::overload_cast<const PathSimulator<>::SimulationPath::Components&, bool>(&PathSimulator<>::setSimulationPath));
-    addCommonSimulatorMethods(pathSimulator);
 
     // Unitary Simulator
     py::enum_<UnitarySimulator<>::Mode>(m, "ConstructionMode")
@@ -233,8 +232,8 @@ PYBIND11_MODULE(pyddsim, m) {
             .value("sequential", UnitarySimulator<>::Mode::Sequential)
             .export_values();
 
-    auto unitarySimulator = py::class_<UnitarySimulator<>>(m, "UnitarySimulator");
-    unitarySimulator.def(py::init<>(&createSimulator<UnitarySimulator<>, UnitarySimulator<>::Mode&>),
+    auto unitarySimulator = createSimulator<UnitarySimulator<>>(m, "UnitarySimulator");
+    unitarySimulator.def(py::init<>(&constructSimulator<UnitarySimulator<>, UnitarySimulator<>::Mode&>),
                          "circ"_a,
                          "approximation_step_fidelity"_a = 1.,
                          "approximation_steps"_a         = 1,
@@ -245,7 +244,6 @@ PYBIND11_MODULE(pyddsim, m) {
             .def("get_construction_time", &UnitarySimulator<>::getConstructionTime)
             .def("get_final_node_count", &UnitarySimulator<>::getFinalNodeCount)
             .def("get_max_node_count", &UnitarySimulator<>::getMaxNodeCount);
-    addCommonSimulatorMethods(unitarySimulator);
 
     // Miscellaneous functions
     m.def("get_matrix", &getNumpyMatrix<>, "sim"_a, "mat"_a);

--- a/mqt/ddsim/bindings.cpp
+++ b/mqt/ddsim/bindings.cpp
@@ -150,6 +150,7 @@ void addCommonSimulatorMethods(py::class_<Simulator>& cls) {
             .def("get_active_matrix_node_count", &Simulator::getMatrixActiveNodeCount, "Get the number of active matrix nodes, i.e., the number of matrix DD nodes in the unique table with a non-zero reference count.")
             .def("get_max_vector_node_count", &Simulator::getMaxNodeCount, "Get the maximum number of (active) vector nodes, i.e., the maximum number of vector DD nodes in the unique table at any point during the simulation.")
             .def("get_max_matrix_node_count", &Simulator::getMaxMatrixNodeCount, "Get the maximum number of (active) matrix nodes, i.e., the maximum number of matrix DD nodes in the unique table at any point during the simulation.")
+            .def("get_tolerance", &Simulator::getTolerance, "Get the tolerance for the DD package.")
             .def("set_tolerance", &Simulator::setTolerance, "tol"_a, "Set the tolerance for the DD package.");
 
     if constexpr (std::is_same_v<Simulator, UnitarySimulator<>>) {

--- a/test/test_circuit_sim.cpp
+++ b/test/test_circuit_sim.cpp
@@ -258,3 +258,18 @@ TEST(CircuitSimTest, ApproximationTest) {
     EXPECT_EQ(abs(vec[2]), 0);
     EXPECT_EQ(abs(vec[3]), 0);
 }
+
+TEST(CircuitSimTest, ToleranceTest) {
+    // A small test to make sure that setting and getting the tolerance works
+    auto             qc = std::make_unique<qc::QuantumComputation>(2);
+    CircuitSimulator ddsim(std::move(qc));
+    const auto       tolerance = ddsim.getTolerance();
+    EXPECT_EQ(tolerance, dd::ComplexTable<>::tolerance());
+    const auto newTolerance = 0.1;
+    ddsim.setTolerance(newTolerance);
+    EXPECT_EQ(ddsim.getTolerance(), newTolerance);
+    EXPECT_EQ(dd::ComplexTable<>::tolerance(), newTolerance);
+    ddsim.setTolerance(tolerance);
+    EXPECT_EQ(ddsim.getTolerance(), tolerance);
+    EXPECT_EQ(dd::ComplexTable<>::tolerance(), tolerance);
+}


### PR DESCRIPTION
This tiny little PR allows for setting the DD package tolerance for Simulators from Python by exposing a `set_tolerance(tol: float)` method in all simulators.
It also takes the opportunity and extracts some common functionality from all simulators in the Python-C++ bindings and eliminates redundant code.
As a neat side effect, the active as well as the maximum node count are exposed to Python as well.