### PR TITLE
✨ Expose expectation value computation from DD Package to DDSIM

### DIFF
--- a/include/CircuitSimulator.hpp
+++ b/include/CircuitSimulator.hpp
@@ -73,6 +73,8 @@ public:
 
     std::map<std::string, std::size_t> simulate(std::size_t shots) override;
 
+    virtual dd::fp expectationValue(const qc::QuantumComputation& observable);
+
     std::map<std::string, std::string> additionalStatistics() override {
         return {
                 {"step_fidelity", std::to_string(approximationInfo.stepFidelity)},

--- a/mqt/ddsim/bindings.cpp
+++ b/mqt/ddsim/bindings.cpp
@@ -179,7 +179,7 @@ PYBIND11_MODULE(pyddsim, m) {
                          "approximation_steps"_a         = 1,
                          "approximation_strategy"_a      = "fidelity",
                          "seed"_a                        = -1);
-                    .def("expectation_value", &expectationValue, "observable"_a);
+    .def("expectation_value", &expectationValue, "observable"_a);
 
     // Hybrid Schrödinger-Feynman Simulator
     py::enum_<HybridSchrodingerFeynmanSimulator<>::Mode>(m, "HybridMode")

--- a/mqt/ddsim/bindings.cpp
+++ b/mqt/ddsim/bindings.cpp
@@ -141,6 +141,11 @@ void dumpTensorNetwork(const py::object& circ, const std::string& filename) {
     qc->dump(ofs, qc::Format::Tensor);
 }
 
+dd::fp expectationValue(CircuitSimulator<>& sim, const py::object& observable) {
+    const auto observableCircuit = importCircuit(observable);
+    return sim.expectationValue(observableCircuit);
+}
+
 PYBIND11_MODULE(pyddsim, m) {
     m.doc() = "Python interface for the MQT DDSIM quantum circuit simulator";
 
@@ -156,7 +161,8 @@ PYBIND11_MODULE(pyddsim, m) {
             .def("get_name", &CircuitSimulator<>::getName)
             .def("simulate", &CircuitSimulator<>::simulate, "shots"_a)
             .def("statistics", &CircuitSimulator<>::additionalStatistics)
-            .def("get_vector", &CircuitSimulator<>::getVectorComplex);
+            .def("get_vector", &CircuitSimulator<>::getVectorComplex)
+            .def("expectation_value", &expectationValue, "observable"_a);
 
     // Hybrid Schrödinger-Feynman Simulator
     py::enum_<HybridSchrodingerFeynmanSimulator<>::Mode>(m, "HybridMode")

--- a/mqt/ddsim/bindings.cpp
+++ b/mqt/ddsim/bindings.cpp
@@ -179,7 +179,7 @@ PYBIND11_MODULE(pyddsim, m) {
                          "approximation_steps"_a         = 1,
                          "approximation_strategy"_a      = "fidelity",
                          "seed"_a                        = -1)
-                    .def("expectation_value", &expectationValue, "observable"_a);
+            .def("expectation_value", &expectationValue, "observable"_a);
 
     // Hybrid Schrödinger-Feynman Simulator
     py::enum_<HybridSchrodingerFeynmanSimulator<>::Mode>(m, "HybridMode")

--- a/mqt/ddsim/bindings.cpp
+++ b/mqt/ddsim/bindings.cpp
@@ -178,8 +178,8 @@ PYBIND11_MODULE(pyddsim, m) {
                          "approximation_step_fidelity"_a = 1.,
                          "approximation_steps"_a         = 1,
                          "approximation_strategy"_a      = "fidelity",
-                         "seed"_a                        = -1);
-    .def("expectation_value", &expectationValue, "observable"_a);
+                         "seed"_a                        = -1)
+                    .def("expectation_value", &expectationValue, "observable"_a);
 
     // Hybrid Schrödinger-Feynman Simulator
     py::enum_<HybridSchrodingerFeynmanSimulator<>::Mode>(m, "HybridMode")

--- a/src/CircuitSimulator.cpp
+++ b/src/CircuitSimulator.cpp
@@ -1,7 +1,9 @@
 #include "CircuitSimulator.hpp"
 
+#include "CircuitOptimizer.hpp"
 #include "Operations.hpp"
 #include "dd/Export.hpp"
+#include "dd/FunctionalityConstruction.hpp"
 
 template<class Config>
 std::map<std::string, std::size_t> CircuitSimulator<Config>::simulate(std::size_t shots) {
@@ -81,6 +83,18 @@ std::map<std::string, std::size_t> CircuitSimulator<Config>::simulate(std::size_
         measurementCounter[resultString]++;
     }
     return measurementCounter;
+}
+
+template<class Config>
+dd::fp CircuitSimulator<Config>::expectationValue(const qc::QuantumComputation& observable) {
+    // simulate the circuit to get the state vector
+    simulate(0);
+
+    // construct the DD for the observable
+    const auto observableDD = dd::buildFunctionality(&observable, Simulator<Config>::dd);
+
+    // calculate the expectation value
+    return Simulator<Config>::dd->expectationValue(observableDD, Simulator<Config>::rootEdge);
 }
 
 template<class Config>

--- a/src/CircuitSimulator.cpp
+++ b/src/CircuitSimulator.cpp
@@ -88,7 +88,7 @@ std::map<std::string, std::size_t> CircuitSimulator<Config>::simulate(std::size_
 template<class Config>
 dd::fp CircuitSimulator<Config>::expectationValue(const qc::QuantumComputation& observable) {
     // simulate the circuit to get the state vector
-    simulate(0);
+    singleShot(true);
 
     // construct the DD for the observable
     const auto observableDD = dd::buildFunctionality(&observable, Simulator<Config>::dd);

--- a/test/python/simulator/test_standalone_simulator.py
+++ b/test/python/simulator/test_standalone_simulator.py
@@ -59,3 +59,41 @@ class MQTStandaloneSimulatorTests(unittest.TestCase):
         assert len(result.keys()) == self.nonzero_states_ghz
         assert "00" in result
         assert "01" in result
+
+    @staticmethod
+    def test_expectation_value_local_operators():
+        import numpy as np
+
+        max_qubits = 3
+        for qubits in range(1, max_qubits + 1):
+            qc = QuantumCircuit(qubits)
+            sim = ddsim.CircuitSimulator(qc)
+            for i in range(qubits):
+                x_observable = QuantumCircuit(qubits)
+                x_observable.x(i)
+                assert sim.expectation_value(x_observable) == 0
+                z_observable = QuantumCircuit(qubits)
+                z_observable.z(i)
+                assert sim.expectation_value(z_observable) == 1
+                h_observable = QuantumCircuit(qubits)
+                h_observable.h(i)
+                assert np.allclose(sim.expectation_value(h_observable), 1 / np.sqrt(2))
+
+    @staticmethod
+    def test_expectation_value_global_operators():
+        import numpy as np
+
+        max_qubits = 3
+        for qubits in range(1, max_qubits + 1):
+            qc = QuantumCircuit(qubits)
+            sim = ddsim.CircuitSimulator(qc)
+            x_observable = QuantumCircuit(qubits)
+            z_observable = QuantumCircuit(qubits)
+            h_observable = QuantumCircuit(qubits)
+            for i in range(qubits):
+                x_observable.x(i)
+                z_observable.z(i)
+                h_observable.h(i)
+            assert sim.expectation_value(x_observable) == 0
+            assert sim.expectation_value(z_observable) == 1
+            assert np.allclose(sim.expectation_value(h_observable), (1 / np.sqrt(2)) ** qubits)

--- a/test/test_circuit_sim.cpp
+++ b/test/test_circuit_sim.cpp
@@ -258,3 +258,41 @@ TEST(CircuitSimTest, ApproximationTest) {
     EXPECT_EQ(abs(vec[2]), 0);
     EXPECT_EQ(abs(vec[3]), 0);
 }
+
+TEST(CircuitSimTest, expectationValueLocalOperators) {
+    const std::size_t maxQubits = 3;
+    for (std::size_t nrQubits = 1; nrQubits < maxQubits; ++nrQubits) {
+        auto             qc = std::make_unique<qc::QuantumComputation>(nrQubits);
+        CircuitSimulator ddsim(std::move(qc));
+        for (qc::Qubit site = 0; site < nrQubits; ++site) {
+            auto xObservable = qc::QuantumComputation(nrQubits);
+            xObservable.x(site);
+            EXPECT_EQ(ddsim.expectationValue(xObservable), 0);
+            auto zObservable = qc::QuantumComputation(nrQubits);
+            zObservable.z(site);
+            EXPECT_EQ(ddsim.expectationValue(zObservable), 1);
+            auto hObservable = qc::QuantumComputation(nrQubits);
+            hObservable.h(site);
+            EXPECT_EQ(ddsim.expectationValue(hObservable), dd::SQRT2_2);
+        }
+    }
+}
+
+TEST(CircuitSimTest, expectationValueGlobalOperators) {
+    const std::size_t maxQubits = 3;
+    for (std::size_t nrQubits = 1; nrQubits < maxQubits; ++nrQubits) {
+        auto             qc = std::make_unique<qc::QuantumComputation>(nrQubits);
+        CircuitSimulator ddsim(std::move(qc));
+        auto             xObservable = qc::QuantumComputation(nrQubits);
+        auto             zObservable = qc::QuantumComputation(nrQubits);
+        auto             hObservable = qc::QuantumComputation(nrQubits);
+        for (qc::Qubit site = 0; site < nrQubits; ++site) {
+            xObservable.x(site);
+            zObservable.z(site);
+            hObservable.h(site);
+        }
+        EXPECT_EQ(ddsim.expectationValue(xObservable), 0);
+        EXPECT_EQ(ddsim.expectationValue(zObservable), 1);
+        EXPECT_EQ(ddsim.expectationValue(hObservable), std::pow(dd::SQRT2_2, nrQubits));
+    }
+}


### PR DESCRIPTION
This small PR exposes the newly added expectation value functionality from the DD Package to the `CircuitSimulator` in C++ as well as Python.
This allows to compute expectation values of observables that can be specified as quantum circuits. On the Python side, Qiskit `QuantumCircuit`s can be conveniently used.