### PR TITLE
Update QFR and fix two tests

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -32,8 +32,7 @@ jobs:
       - name: Build
         run: cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE
       - name: Test
-        working-directory: ${{github.workspace}}/build/test
-        run: ctest -C $BUILD_TYPE --output-on-failure
+        run: ctest -C $BUILD_TYPE --output-on-failure --test-dir build --repeat until-pass:3 --timeout 300
 
   build-macos:
     name: Build and Test on MacOS
@@ -48,9 +47,7 @@ jobs:
       - name: Build
         run: cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE
       - name: Test
-        working-directory: ${{github.workspace}}/build/test
-        shell: bash
-        run: ctest -C $BUILD_TYPE --output-on-failure
+        run: ctest -C $BUILD_TYPE --output-on-failure --test-dir build --repeat until-pass:3 --timeout 300
 
   build-windows:
     name: Build and Test on Windows
@@ -66,8 +63,7 @@ jobs:
       - name: Build
         run: cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE
       - name: Test
-        working-directory: ${{github.workspace}}/build/test
-        run: cd $BUILD_TYPE && ./ddsim_test
+        run: ctest -C $BUILD_TYPE --output-on-failure --test-dir build --repeat until-pass:3 --timeout 300
 
   coverage:
     name: Coverage

--- a/test/python/simulator/test_standalone_simulator.py
+++ b/test/python/simulator/test_standalone_simulator.py
@@ -50,9 +50,11 @@ class MQTStandaloneSimulatorTests(unittest.TestCase):
         circ = QuantumCircuit(2)
         circ.h(0)
         circ.cry(np.pi / 8, 0, 1)
+        circ.i(0)
+        circ.i(0)
 
         # create a simulator that approximates once and by at most 2%
-        sim = ddsim.CircuitSimulator(circ, approximation_step_fidelity=0.98, approximation_steps=3)
+        sim = ddsim.CircuitSimulator(circ, approximation_step_fidelity=0.98, approximation_steps=1)
         result = sim.simulate(4096)
 
         # the result should always be 0

--- a/test/python/taskbasedsimulator/test_path_sim_standalone_simulator.py
+++ b/test/python/taskbasedsimulator/test_path_sim_standalone_simulator.py
@@ -45,7 +45,6 @@ class MQTStandaloneSimulatorTests(unittest.TestCase):
         assert "000" in result
         assert "111" in result
 
-    @unittest.skip("Test times out")
     def test_standalone_individual_objects(self):
         circ = QuantumCircuit(3)
         circ.h(0)


### PR DESCRIPTION
- Update QFR to include fixes for gphase
- PathSim Test does not time out anymore (fixes #211)
- Simplify approxmation test