### PR TITLE
Possible fix for HybridSchroedingerFeynman

### DIFF
--- a/apps/simple.cpp
+++ b/apps/simple.cpp
@@ -22,12 +22,12 @@ namespace nl = nlohmann;
 namespace std {
 
     template<class T>
-    void to_json(nl::json& j, const std::complex<T>& p) {
+    void to_json(nl::json& j, const std::complex<T>& p) { // NOLINT(readability-identifier-naming): this is required by nlohmann
         j = nl::json{p.real(), p.imag()};
     }
 
     template<class T>
-    void from_json(const nl::json& j, std::complex<T>& p) {
+    void from_json(const nl::json& j, std::complex<T>& p) { // NOLINT(readability-identifier-naming): this is required by nlohmann
         p.real(j.at(0));
         p.imag(j.at(1));
     }

--- a/apps/simple.cpp
+++ b/apps/simple.cpp
@@ -19,20 +19,6 @@
 
 namespace nl = nlohmann;
 
-namespace std {
-
-    template<class T>
-    void to_json(nl::json& j, const std::complex<T>& p) { // NOLINT(readability-identifier-naming): this is required by nlohmann
-        j = nl::json{p.real(), p.imag()};
-    }
-
-    template<class T>
-    void from_json(const nl::json& j, std::complex<T>& p) { // NOLINT(readability-identifier-naming): this is required by nlohmann
-        p.real(j.at(0));
-        p.imag(j.at(1));
-    }
-} // namespace std
-
 int main(int argc, char** argv) { // NOLINT(bugprone-exception-escape)
     cxxopts::Options options("MQT DDSIM", "for more information see https://www.cda.cit.tum.de/");
     // clang-format off
@@ -224,14 +210,10 @@ int main(int argc, char** argv) { // NOLINT(bugprone-exception-escape)
     }
 
     if (vm.count("pv") > 0) {
-        if (vm.count("simulate_file_hybrid") > 0) {
-            auto* hsfSim = dynamic_cast<HybridSchrodingerFeynmanSimulator<dd::DDPackageConfig>*>(ddsim.get());
-            if (hsfSim == nullptr) {
-                throw std::runtime_error("'--simulate_file_hybrid' is set but not used");
-            }
-            outputObj["state_vector"] = hsfSim->getFinalAmplitudes();
+        if (auto* hsfSim = dynamic_cast<HybridSchrodingerFeynmanSimulator<>*>(ddsim.get())) {
+            outputObj["state_vector"] = hsfSim->getVectorFromHybridSimulation<std::pair<dd::fp, dd::fp>>();
         } else {
-            outputObj["state_vector"] = ddsim->getVectorPair();
+            outputObj["state_vector"] = ddsim->getVector<std::pair<dd::fp, dd::fp>>();
         }
     }
 

--- a/include/HybridSchrodingerFeynmanSimulator.hpp
+++ b/include/HybridSchrodingerFeynmanSimulator.hpp
@@ -51,7 +51,10 @@ public:
 
     template<class ReturnType = dd::ComplexValue>
     [[nodiscard]] std::vector<ReturnType> getVectorFromHybridSimulation() const {
-        assert(CircuitSimulator<Config>::getNumberOfQubits() < 60); // On 64bit system the vector can hold up to (2^60)-1 elements, if memory permits
+        if (CircuitSimulator<Config>::getNumberOfQubits() >= 60) {
+            // On 64bit system the vector can hold up to (2^60)-1 elements, if memory permits
+            throw std::range_error("getVector only supports less than 60 qubits.");
+        }
         if (getMode() == Mode::Amplitude) {
             if constexpr (std::is_same_v<ReturnType, decltype(finalAmplitudes)>) {
                 return finalAmplitudes;

--- a/include/HybridSchrodingerFeynmanSimulator.hpp
+++ b/include/HybridSchrodingerFeynmanSimulator.hpp
@@ -49,7 +49,19 @@ public:
 
     Mode mode = Mode::Amplitude;
 
-    [[nodiscard]] const std::vector<std::complex<dd::fp>>& getFinalAmplitudes() const { return finalAmplitudes; }
+    template<class ReturnType = dd::ComplexValue>
+    [[nodiscard]] std::vector<ReturnType> getVectorFromHybridSimulation() const {
+        assert(CircuitSimulator<Config>::getNumberOfQubits() < 60); // On 64bit system the vector can hold up to (2^60)-1 elements, if memory permits
+        if (getMode() == Mode::Amplitude) {
+            if constexpr (std::is_same_v<ReturnType, decltype(finalAmplitudes)>) {
+                return finalAmplitudes;
+            }
+            std::vector<ReturnType> amplitudes;
+            std::transform(finalAmplitudes.begin(), finalAmplitudes.end(), std::back_inserter(amplitudes), [](std::complex<dd::fp> x) -> ReturnType { return {x.real(), x.imag()}; });
+            return amplitudes;
+        }
+        return CircuitSimulator<Config>::template getVector<ReturnType>();
+    }
 
     //  Get # of decisions for given split_qubit, so that lower slice: q0 < i < qubit; upper slice: qubit <= i < nqubits
     std::size_t getNDecisions(qc::Qubit splitQubit);

--- a/include/Simulator.hpp
+++ b/include/Simulator.hpp
@@ -66,11 +66,20 @@ public:
 
     std::map<std::string, std::size_t> sampleFromAmplitudeVectorInPlace(std::vector<std::complex<dd::fp>>& amplitudes, std::size_t shots);
 
-    [[nodiscard]] std::vector<dd::ComplexValue> getVector() const;
-
-    [[nodiscard]] std::vector<std::pair<dd::fp, dd::fp>> getVectorPair() const;
-
-    [[nodiscard]] std::vector<std::complex<dd::fp>> getVectorComplex() const;
+    template<class ReturnType = dd::ComplexValue>
+    [[nodiscard]] std::vector<ReturnType> getVector() const {
+        assert(getNumberOfQubits() < 60); // On 64bit system the vector can hold up to (2^60)-1 elements, if memory permits
+        std::string             path(getNumberOfQubits(), '0');
+        std::vector<ReturnType> results;
+        results.resize(1ULL << getNumberOfQubits());
+        for (std::size_t i = 0; i < 1ULL << getNumberOfQubits(); ++i) {
+            const std::string      correctedPath{path.rbegin(), path.rend()};
+            const dd::ComplexValue cv = dd->getValueByPath(rootEdge, correctedPath);
+            results[i]                = {cv.r, cv.i};
+            nextPath(path);
+        }
+        return results;
+    }
 
     [[nodiscard]] virtual std::size_t getActiveNodeCount() const { return dd->vUniqueTable.getActiveNodeCount(); }
 

--- a/include/Simulator.hpp
+++ b/include/Simulator.hpp
@@ -68,7 +68,10 @@ public:
 
     template<class ReturnType = dd::ComplexValue>
     [[nodiscard]] std::vector<ReturnType> getVector() const {
-        assert(getNumberOfQubits() < 60); // On 64bit system the vector can hold up to (2^60)-1 elements, if memory permits
+        if (getNumberOfQubits() >= 60) {
+            // On 64bit system the vector can hold up to (2^60)-1 elements, if memory permits
+            throw std::range_error("getVector only supports less than 60 qubits.");
+        }
         std::string             path(getNumberOfQubits(), '0');
         std::vector<ReturnType> results;
         results.resize(1ULL << getNumberOfQubits());

--- a/mqt/ddsim/bindings.cpp
+++ b/mqt/ddsim/bindings.cpp
@@ -163,7 +163,7 @@ py::class_<Sim> createSimulator(py::module_ m, const std::string& name) {
         sim.def("construct", &Sim::construct, "Construct the DD representing the unitary matrix of the circuit.");
     } else {
         sim.def("simulate", &Sim::simulate, "shots"_a, "Simulate the circuit and return the result as a dictionary of counts.");
-        sim.def("get_vector", &Sim::getVectorComplex, "Get the state vector resulting from the simulation.");
+        sim.def("get_vector", &Sim::template getVector<std::complex<dd::fp>>, "Get the state vector resulting from the simulation.");
     }
     return sim;
 }
@@ -197,7 +197,7 @@ PYBIND11_MODULE(pyddsim, m) {
                      "mode"_a                        = HybridSchrodingerFeynmanSimulator<>::Mode::Amplitude,
                      "nthreads"_a                    = 2)
             .def("get_mode", &HybridSchrodingerFeynmanSimulator<>::getMode)
-            .def("get_final_amplitudes", &HybridSchrodingerFeynmanSimulator<>::getFinalAmplitudes);
+            .def("get_final_amplitudes", &HybridSchrodingerFeynmanSimulator<>::template getVectorFromHybridSimulation<std::complex<dd::fp>>);
 
     // Path Simulator
     py::enum_<PathSimulator<>::Configuration::Mode>(m, "PathSimulatorMode")

--- a/src/HybridSchrodingerFeynmanSimulator.cpp
+++ b/src/HybridSchrodingerFeynmanSimulator.cpp
@@ -217,7 +217,7 @@ void HybridSchrodingerFeynmanSimulator<Config>::simulateHybridAmplitudes(qc::Qub
     const std::size_t nqubits             = CircuitSimulator<Config>::getNumberOfQubits();
     Simulator<Config>::rootEdge           = qc::VectorDD::zero;
 
-    std::vector<std::vector<std::complex<dd::fp>>> amplitudes(actuallyUsedThreads, std::vector<std::complex<dd::fp>>(1U << nqubits, {0, 0}));
+    std::vector<std::vector<std::complex<dd::fp>>> amplitudes(maxControl / nslicesOnOneCpu, std::vector<std::complex<dd::fp>>(1U << nqubits, {0, 0}));
 
     tf::Executor executor;
     for (std::size_t control = 0, i = 0; control < maxControl; control += nslicesOnOneCpu, i++) {

--- a/src/Simulator.cpp
+++ b/src/Simulator.cpp
@@ -35,49 +35,6 @@ std::map<std::string, std::size_t> Simulator<Config>::sampleFromAmplitudeVectorI
 }
 
 template<class Config>
-std::vector<dd::ComplexValue> Simulator<Config>::getVector() const {
-    assert(getNumberOfQubits() < 60); // On 64bit system the vector can hold up to (2^60)-1 elements, if memory permits
-    std::string                   path(getNumberOfQubits(), '0');
-    std::vector<dd::ComplexValue> results(1ULL << getNumberOfQubits(), dd::complex_zero);
-    for (std::size_t i = 0; i < 1ULL << getNumberOfQubits(); ++i) {
-        const std::string correctedPath{path.rbegin(), path.rend()};
-        results[i] = dd->getValueByPath(rootEdge, correctedPath);
-        nextPath(path);
-    }
-    return results;
-}
-
-template<class Config>
-std::vector<std::pair<dd::fp, dd::fp>> Simulator<Config>::getVectorPair() const {
-    assert(getNumberOfQubits() < 60); // On 64bit system the vector can hold up to (2^60)-1 elements, if memory permits
-    std::string                            path(getNumberOfQubits(), '0');
-    std::vector<std::pair<dd::fp, dd::fp>> results{1ULL << getNumberOfQubits()};
-
-    for (std::size_t i = 0; i < 1ULL << getNumberOfQubits(); ++i) {
-        const std::string      correctedPath{path.rbegin(), path.rend()};
-        const dd::ComplexValue cv = dd->getValueByPath(rootEdge, correctedPath);
-        results[i]                = std::make_pair(cv.r, cv.i);
-        nextPath(path);
-    }
-    return results;
-}
-
-template<class Config>
-std::vector<std::complex<dd::fp>> Simulator<Config>::getVectorComplex() const {
-    assert(getNumberOfQubits() < 60); // On 64bit system the vector can hold up to (2^60)-1 elements, if memory permits
-    std::string                       path(getNumberOfQubits(), '0');
-    std::vector<std::complex<dd::fp>> results(1ULL << getNumberOfQubits());
-
-    for (std::size_t i = 0; i < 1ULL << getNumberOfQubits(); ++i) {
-        const std::string      correctedPath{path.rbegin(), path.rend()};
-        const dd::ComplexValue cv = dd->getValueByPath(rootEdge, correctedPath);
-        results[i]                = std::complex<dd::fp>(cv.r, cv.i);
-        nextPath(path);
-    }
-    return results;
-}
-
-template<class Config>
 void Simulator<Config>::nextPath(std::string& s) {
     std::string::reverse_iterator       iter = s.rbegin();
     const std::string::reverse_iterator end  = s.rend();

--- a/test/test_circuit_sim.cpp
+++ b/test/test_circuit_sim.cpp
@@ -312,9 +312,9 @@ TEST(CircuitSimTest, ToleranceTest) {
     EXPECT_EQ(dd::ComplexTable<>::tolerance(), tolerance);
 }
 
-TEST(CircuitSimDeathTest, TooManyQubitsForVectorTest) {
+TEST(CircuitSimTest, TooManyQubitsForVectorTest) {
     auto             qc = std::make_unique<qc::QuantumComputation>(61);
     CircuitSimulator ddsim(std::move(qc));
     ddsim.simulate(0);
-    ASSERT_DEATH({ [[maybe_unused]] auto _ = ddsim.getVector<std::complex<dd::fp>>(); }, "");
+    EXPECT_THROW({ [[maybe_unused]] auto _ = ddsim.getVector<std::complex<dd::fp>>(); }, std::range_error);
 }

--- a/test/test_circuit_sim.cpp
+++ b/test/test_circuit_sim.cpp
@@ -316,5 +316,5 @@ TEST(CircuitSimDeathTest, TooManyQubitsForVectorTest) {
     auto             qc = std::make_unique<qc::QuantumComputation>(61);
     CircuitSimulator ddsim(std::move(qc));
     ddsim.simulate(0);
-    ASSERT_DEATH({ [[maybe_unused]] auto _ = ddsim.getVector<std::complex<dd::fp>>(); }, "getVector failed as expected");
+    ASSERT_DEATH({ [[maybe_unused]] auto _ = ddsim.getVector<std::complex<dd::fp>>(); }, "");
 }

--- a/test/test_circuit_sim.cpp
+++ b/test/test_circuit_sim.cpp
@@ -143,8 +143,8 @@ TEST(CircuitSimTest, DestructiveMeasurementOne) {
         FAIL() << "Measurement result not in {0,1}!";
     }
 
-    const auto vAfterPairs = ddsim.getVectorPair();
-    const auto vAfterCompl = ddsim.getVectorComplex();
+    const auto vAfterPairs = ddsim.getVector<std::pair<dd::fp, dd::fp>>();
+    const auto vAfterCompl = ddsim.getVector<std::complex<dd::fp>>();
 
     ASSERT_EQ(vAfterPairs.size(), vAfterCompl.size());
     for (std::size_t i = 0; i < vAfterPairs.size(); i++) {
@@ -254,7 +254,7 @@ TEST(CircuitSimTest, ApproximationTest) {
     // approximating the state with fidelity 0.98 should allow to eliminate the 1-successor of the first qubit
     CircuitSimulator ddsim(std::move(qc), ApproximationInfo(0.98, 2, ApproximationInfo::FidelityDriven));
     ddsim.simulate(4096);
-    const auto vec = ddsim.getVectorComplex();
+    const auto vec = ddsim.getVector<std::complex<dd::fp>>();
     EXPECT_EQ(abs(vec[2]), 0);
     EXPECT_EQ(abs(vec[3]), 0);
 }

--- a/test/test_circuit_sim.cpp
+++ b/test/test_circuit_sim.cpp
@@ -311,3 +311,10 @@ TEST(CircuitSimTest, ToleranceTest) {
     EXPECT_EQ(ddsim.getTolerance(), tolerance);
     EXPECT_EQ(dd::ComplexTable<>::tolerance(), tolerance);
 }
+
+TEST(CircuitSimDeathTest, TooManyQubitsForVectorTest) {
+    auto             qc = std::make_unique<qc::QuantumComputation>(61);
+    CircuitSimulator ddsim(std::move(qc));
+    ddsim.simulate(0);
+    ASSERT_DEATH({ [[maybe_unused]] auto _ = ddsim.getVector<std::complex<dd::fp>>(); }, "getVector failed as expected");
+}

--- a/test/test_hybridsim.cpp
+++ b/test/test_hybridsim.cpp
@@ -116,17 +116,14 @@ TEST(HybridSimTest, GRCSTestAmplitudes) {
     ddsim.simulate(0);
 
     // if edges are not equal -> compare amplitudes
-    auto        refAmplitudes    = ddsim.getVector();
-    const auto& resultAmplitudes = ddsimHybridAmp.getFinalAmplitudes();
-    bool        equal            = true;
+    const auto refAmplitudes    = ddsim.getVector();
+    const auto resultAmplitudes = ddsimHybridAmp.getVectorFromHybridSimulation<std::complex<dd::fp>>();
     for (std::size_t i = 0; i < refAmplitudes.size(); ++i) {
         if (std::abs(refAmplitudes[i].r - resultAmplitudes[i].real()) > 1e-6 || std::abs(refAmplitudes[i].i - resultAmplitudes[i].imag()) > 1e-6) {
-            equal = false;
-            break;
+            FAIL() << "Differing values on entry " << i;
         }
     }
-
-    EXPECT_TRUE(equal);
+    SUCCEED();
 }
 
 TEST(HybridSimTest, GRCSTestFixedSeed) {
@@ -141,17 +138,37 @@ TEST(HybridSimTest, GRCSTestFixedSeed) {
     ddsim.simulate(0);
 
     // if edges are not equal -> compare amplitudes
-    auto        refAmplitudes    = ddsim.getVector();
-    const auto& resultAmplitudes = ddsimHybridAmp.getFinalAmplitudes();
-    bool        equal            = true;
+    const auto refAmplitudes    = ddsim.getVector();
+    const auto resultAmplitudes = ddsimHybridAmp.getVectorFromHybridSimulation<std::complex<dd::fp>>();
     for (std::size_t i = 0; i < refAmplitudes.size(); ++i) {
         if (std::abs(refAmplitudes[i].r - resultAmplitudes[i].real()) > 1e-6 || std::abs(refAmplitudes[i].i - resultAmplitudes[i].imag()) > 1e-6) {
-            equal = false;
-            break;
+            FAIL() << "Differing values on entry " << i;
         }
     }
+    SUCCEED();
+}
 
-    EXPECT_TRUE(equal);
+TEST(HybridSimTest, GRCSTestFixedSeedDifferentVectorType) {
+    auto qc1 = std::make_unique<qc::QuantumComputation>("circuits/inst_4x4_10_0.txt");
+    auto qc2 = std::make_unique<qc::QuantumComputation>("circuits/inst_4x4_10_0.txt");
+
+    HybridSchrodingerFeynmanSimulator<> ddsimHybridAmp(std::move(qc1), ApproximationInfo{}, 42);
+    EXPECT_TRUE(ddsimHybridAmp.getMode() == HybridSchrodingerFeynmanSimulator<>::Mode::Amplitude);
+    HybridSchrodingerFeynmanSimulator<> ddsimHybridDD(std::move(qc2), ApproximationInfo{}, HybridSchrodingerFeynmanSimulator<>::Mode::DD);
+    EXPECT_TRUE(ddsimHybridDD.getMode() == HybridSchrodingerFeynmanSimulator<>::Mode::DD);
+
+    ddsimHybridAmp.simulate(0);
+    ddsimHybridDD.simulate(0);
+
+    // if edges are not equal -> compare amplitudes
+    const auto refAmplitudes    = ddsimHybridDD.getVectorFromHybridSimulation<dd::ComplexValue>();
+    const auto resultAmplitudes = ddsimHybridAmp.getVectorFromHybridSimulation<std::pair<dd::fp, dd::fp>>();
+    for (std::size_t i = 0; i < refAmplitudes.size(); ++i) {
+        if (std::abs(refAmplitudes[i].r - resultAmplitudes[i].first) > 1e-6 || std::abs(refAmplitudes[i].i - resultAmplitudes[i].second) > 1e-6) {
+            FAIL() << "Differing values on entry " << i;
+        }
+    }
+    SUCCEED();
 }
 
 TEST(HybridSimTest, NonStandardOperation) {

--- a/test/test_hybridsim.cpp
+++ b/test/test_hybridsim.cpp
@@ -89,20 +89,17 @@ TEST(HybridSimTest, GRCSTestDD) {
     auto result = dd->deserialize<dd::vNode>("result_parallel.dd", true);
     auto ref    = dd->deserialize<dd::vNode>("result.dd", true);
 
-    bool equal = (result == ref);
-    if (!equal) {
+    if (result != ref) {
         // if edges are not equal -> compare amplitudes
         auto refAmplitudes    = dd->getVector(ref);
         auto resultAmplitudes = dd->getVector(result);
-        equal                 = true;
         for (std::size_t i = 0; i < refAmplitudes.size(); ++i) {
             if (std::abs(refAmplitudes[i].real() - resultAmplitudes[i].real()) > 1e-6 || std::abs(refAmplitudes[i].imag() - resultAmplitudes[i].imag()) > 1e-6) {
-                equal = false;
-                break;
+                FAIL() << "Differing values on entry " << i;
             }
         }
     }
-    EXPECT_TRUE(equal);
+    SUCCEED();
 }
 
 TEST(HybridSimTest, GRCSTestAmplitudes) {

--- a/test/test_hybridsim.cpp
+++ b/test/test_hybridsim.cpp
@@ -179,3 +179,9 @@ TEST(HybridSimTest, NonStandardOperation) {
     HybridSchrodingerFeynmanSimulator ddsim(std::move(quantumComputation));
     EXPECT_THROW(ddsim.simulate(0), std::invalid_argument);
 }
+
+TEST(HybridSimTest, TooManyQubitsForVectorTest) {
+    auto                                      qc = std::make_unique<qc::QuantumComputation>(61);
+    const HybridSchrodingerFeynmanSimulator<> ddsim(std::move(qc), ApproximationInfo{}, HybridSchrodingerFeynmanSimulator<>::Mode::Amplitude);
+    EXPECT_THROW({ [[maybe_unused]] auto _ = ddsim.getVectorFromHybridSimulation<std::complex<dd::fp>>(); }, std::range_error);
+}


### PR DESCRIPTION
The Hybrid Schrödinger Feynman Simulator is buggy and sometimes does not terminate, see #215 

One possible reason is the previously wrong allocation of the amplitude vector vector.

Remark: Unfortunately `virtual` function cannot be templated, so there has to be this ugly work-around for the Hybrid-Schrödinger-Feynman-Simulator of creating a new and none-overloading function for its `getVector...`.