### PR TITLE
Update clang-format version for pre-commit

### DIFF
--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           pipx run cpp-linter \
           --version=14 \
-          --style="file" \
+          --style="" \
           --tidy-checks="" \
           --thread-comments=true \
           --files-changed-only=true \

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,20 +59,20 @@ repos:
 
   # Clang-format the C++ part of the code base automatically
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v14.0.6
+    rev: v16.0.0
     hooks:
       - id: clang-format
         types_or: [c++, c, cuda]
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.259
+    rev: v0.0.260
     hooks:
       - id: ruff
         args: ["--fix"]
 
   # Run code formatting with Black
   - repo: https://github.com/psf/black
-    rev: 23.1.0 # Keep in sync with blacken-docs
+    rev: 23.3.0 # Keep in sync with blacken-docs
     hooks:
       - id: black-jupyter
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,7 +82,7 @@ repos:
     hooks:
       - id: blacken-docs
         additional_dependencies:
-          - black==23.1.0 # keep in sync with black hook
+          - black==23.3.0 # keep in sync with black hook
 
   # Format configuration files with prettier
   - repo: https://github.com/pre-commit/mirrors-prettier


### PR DESCRIPTION
Update clang-format version for pre-commit and deactivate formatting in cpp-linter.