### PR TITLE
Fix Error in Docs Leading to Missing Info on Bindings

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -110,3 +110,25 @@ GENERATE_XML           = YES
 # This tag requires that the tag GENERATE_XML is set to YES.
 
 XML_OUTPUT             = xml
+
+#---------------------------------------------------------------------------
+# Configuration options related to the dot tool
+#---------------------------------------------------------------------------
+
+# If the CLASS_DIAGRAMS tag is set to YES, doxygen will generate a class diagram
+# (in HTML and LaTeX) for classes with base or super classes. Setting the tag to
+# NO turns the diagrams off. Note that this option also works with HAVE_DOT
+# disabled, but it is recommended to install and use dot, since it yields more
+# powerful graphs.
+# The default value is: YES.
+
+CLASS_DIAGRAMS         = NO
+
+# If you set the HAVE_DOT tag to YES then doxygen will assume the dot tool is
+# available from the path. This tool is part of Graphviz (see:
+# http://www.graphviz.org/), a graph visualization toolkit from AT&T and Lucent
+# Bell Labs. The other options in this section have no effect if this option is
+# set to NO
+# The default value is: YES.
+
+HAVE_DOT               = NO

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -132,3 +132,12 @@ CLASS_DIAGRAMS         = NO
 # The default value is: YES.
 
 HAVE_DOT               = NO
+
+#---------------------------------------------------------------------------
+# Configuration options related to the LaTeX output
+#---------------------------------------------------------------------------
+
+# If the GENERATE_LATEX tag is set to YES, doxygen will generate LaTeX output.
+# The default value is: YES.
+
+GENERATE_LATEX         = NO

--- a/docs/source/api/ddsim.rst
+++ b/docs/source/api/ddsim.rst
@@ -88,7 +88,7 @@ ddsim.statevectorsimulator module
 ddsim.unitarysimulator module
 -----------------------------
 
-.. automodule:: ddsim.unitarysimulator
+.. automodule:: mqt.ddsim.unitarysimulator
    :members:
    :undoc-members:
    :show-inheritance:
@@ -96,7 +96,7 @@ ddsim.unitarysimulator module
 Module contents
 ---------------
 
-.. automodule:: ddsim
+.. automodule:: mqt.ddsim
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/api/ddsim.rst
+++ b/docs/source/api/ddsim.rst
@@ -7,7 +7,7 @@ Submodules
 ddsim.error module
 ------------------
 
-.. automodule:: ddsim.error
+.. automodule:: mqt.ddsim.error
    :members:
    :undoc-members:
    :show-inheritance:
@@ -15,7 +15,7 @@ ddsim.error module
 ddsim.hybridqasmsimulator module
 --------------------------------
 
-.. automodule:: ddsim.hybridqasmsimulator
+.. automodule:: mqt.ddsim.hybridqasmsimulator
    :members:
    :undoc-members:
    :show-inheritance:
@@ -23,7 +23,7 @@ ddsim.hybridqasmsimulator module
 ddsim.hybridstatevectorsimulator module
 ---------------------------------------
 
-.. automodule:: ddsim.hybridstatevectorsimulator
+.. automodule:: mqt.ddsim.hybridstatevectorsimulator
    :members:
    :undoc-members:
    :show-inheritance:
@@ -31,7 +31,7 @@ ddsim.hybridstatevectorsimulator module
 ddsim.job module
 ----------------
 
-.. automodule:: ddsim.job
+.. automodule:: mqt.ddsim.job
    :members:
    :undoc-members:
    :show-inheritance:
@@ -39,7 +39,7 @@ ddsim.job module
 ddsim.pathqasmsimulator module
 ------------------------------
 
-.. automodule:: ddsim.pathqasmsimulator
+.. automodule:: mqt.ddsim.pathqasmsimulator
    :members:
    :undoc-members:
    :show-inheritance:
@@ -47,7 +47,7 @@ ddsim.pathqasmsimulator module
 ddsim.pathstatevectorsimulator module
 -------------------------------------
 
-.. automodule:: ddsim.pathstatevectorsimulator
+.. automodule:: mqt.ddsim.pathstatevectorsimulator
    :members:
    :undoc-members:
    :show-inheritance:
@@ -55,7 +55,7 @@ ddsim.pathstatevectorsimulator module
 ddsim.provider module
 ---------------------
 
-.. automodule:: ddsim.provider
+.. automodule:: mqt.ddsim.provider
    :members:
    :undoc-members:
    :show-inheritance:
@@ -63,15 +63,16 @@ ddsim.provider module
 ddsim.pyddsim module
 --------------------
 
-.. automodule:: ddsim.pyddsim
+.. automodule:: mqt.ddsim.pyddsim
    :members:
    :undoc-members:
+   :special-members: __init__
    :show-inheritance:
 
 ddsim.qasmsimulator module
 --------------------------
 
-.. automodule:: ddsim.qasmsimulator
+.. automodule:: mqt.ddsim.qasmsimulator
    :members:
    :undoc-members:
    :show-inheritance:
@@ -79,7 +80,7 @@ ddsim.qasmsimulator module
 ddsim.statevectorsimulator module
 ---------------------------------
 
-.. automodule:: ddsim.statevectorsimulator
+.. automodule:: mqt.ddsim.statevectorsimulator
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,7 +13,7 @@ import pybtex.plugin
 from pybtex.style.formatting.unsrt import Style as UnsrtStyle
 from pybtex.style.template import field, href
 
-sys.path.insert(0, str(pathlib.Path("../../mqt").resolve()))
+sys.path.insert(0, str(pathlib.Path("../..").resolve()))
 
 # -- Project information -----------------------------------------------------
 project = "DDSIM"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,7 +13,7 @@ import pybtex.plugin
 from pybtex.style.formatting.unsrt import Style as UnsrtStyle
 from pybtex.style.template import field, href
 
-sys.path.insert(0, str(pathlib.Path("../..").resolve()))
+sys.path.insert(0, pathlib.Path(pathlib.Path(), "../..").resolve().as_posix())
 
 # -- Project information -----------------------------------------------------
 project = "DDSIM"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import pathlib
 import subprocess
-import sys
 from importlib.metadata import version
 from typing import TYPE_CHECKING, Any
 
@@ -12,10 +10,6 @@ if TYPE_CHECKING:
 import pybtex.plugin
 from pybtex.style.formatting.unsrt import Style as UnsrtStyle
 from pybtex.style.template import field, href
-
-mqt_path = pathlib.Path(pathlib.Path(), "../..").resolve().as_posix()
-print("adding to path:", mqt_path)
-sys.path.insert(0, mqt_path)
 
 # -- Project information -----------------------------------------------------
 project = "DDSIM"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,7 +13,9 @@ import pybtex.plugin
 from pybtex.style.formatting.unsrt import Style as UnsrtStyle
 from pybtex.style.template import field, href
 
-sys.path.insert(0, pathlib.Path(pathlib.Path(), "../..").resolve().as_posix())
+mqt_path = pathlib.Path(pathlib.Path(), "../..").resolve().as_posix()
+print("adding to path:", mqt_path)
+sys.path.insert(0, mqt_path)
 
 # -- Project information -----------------------------------------------------
 project = "DDSIM"

--- a/mqt/ddsim/job.py
+++ b/mqt/ddsim/job.py
@@ -11,6 +11,7 @@ def requires_submit(func):
     """
     Decorator to ensure that a submit has been performed before
     calling the method.
+
     Args:
         func (callable): test function to be decorated.
     Returns:
@@ -29,6 +30,7 @@ def requires_submit(func):
 
 class DDSIMJob(JobV1):
     """AerJob class.
+
     Attributes:
         _executor (futures.Executor): executor to handle asynchronous jobs
     """
@@ -44,6 +46,7 @@ class DDSIMJob(JobV1):
 
     def submit(self):
         """Submit the job to the backend for execution.
+
         Raises:
             QobjValidationError: if the JSON serialization of the Qobj passed
             during construction does not validate against the Qobj schema.
@@ -61,6 +64,7 @@ class DDSIMJob(JobV1):
         """Get job result. The behavior is the same as the underlying
         concurrent Future objects,
         https://docs.python.org/3/library/concurrent.futures.html#future-objects
+
         Args:
             timeout (float): number of seconds to wait for results.
         Returns:
@@ -78,6 +82,7 @@ class DDSIMJob(JobV1):
     @requires_submit
     def status(self) -> JobStatus:
         """Gets the status of the job by querying the Python's future
+
         Returns:
             JobStatus: The current JobStatus
         Raises:

--- a/mqt/ddsim/qasmsimulator.py
+++ b/mqt/ddsim/qasmsimulator.py
@@ -30,6 +30,9 @@ class QasmSimulatorBackend(BackendV1):
             shots=None,
             parameter_binds=None,
             simulator_seed=None,
+            approximation_step_fidelity=1.0,
+            approximation_steps=0,
+            approximation_strategy="fidelity",
         )
 
     def __init__(self, configuration=None, provider=None):

--- a/test/python/simulator/test_qasm_simulator.py
+++ b/test/python/simulator/test_qasm_simulator.py
@@ -86,3 +86,20 @@ class MQTQasmSimulatorTest(unittest.TestCase):
         for key in target:
             assert key in counts
             assert abs(target[key] - counts[key]) < threshold
+
+    def test_qasm_simulator_approximation(self):
+        """Test data counts output for single circuit run against reference."""
+        shots = 1024
+        circuit = QuantumCircuit.from_qasm_str(
+            """OPENQASM 2.0;
+            include "qelib1.inc";
+            qreg q[2];
+            h q[0];
+            cx q[0], q[1];
+            """
+        )
+        result = execute(
+            circuit, self.backend, shots=shots, approximation_step_fidelity=0.4, approximation_steps=3
+        ).result()
+        counts = result.get_counts()
+        assert len(counts) == 1


### PR DESCRIPTION
This PR fixes the documention which currently does not include the API docs for bindings. 

The changes also omit unnecessary calls to Graphviz dot and the creation of LaTeX docs by doxygen.

Relates to #224 