### PR TITLE
Add test to cover parameterized gates w/ 2 targets

### DIFF
--- a/test/python/simulator/test_qasm_simulator.py
+++ b/test/python/simulator/test_qasm_simulator.py
@@ -103,3 +103,46 @@ class MQTQasmSimulatorTest(unittest.TestCase):
         ).result()
         counts = result.get_counts()
         assert len(counts) == 1
+
+    def test_qasm_simulator_portfolioqaoa(self):
+        """Run simulator with with 2-target gates that take a parameter. Circuit taken from MQT Bench."""
+        circuit = QuantumCircuit.from_qasm_str(
+            """OPENQASM 2.0;
+            include "qelib1.inc";
+            qreg q[3];
+            creg meas[3];
+            creg meas0[3];
+            u2(0.41951949,-pi) q[0];
+            u2(0.41620669,-pi) q[1];
+            rzz(-0.420917333908502) q[0],q[1];
+            u2(0.41905329,-pi) q[2];
+            rzz(-0.421016123405307) q[0],q[2];
+            u3(2.2348228,1.2558831,-pi/2) q[0];
+            rzz(-0.420940441831552) q[1],q[2];
+            u3(2.2348228,1.2087537,-pi/2) q[1];
+            rzz(-5.98815838177421) q[0],q[1];
+            u3(2.2348228,1.2492507,-pi/2) q[2];
+            rzz(-5.98956380537088) q[0],q[2];
+            u3(0.56042125,-1.2358007,pi/2) q[0];
+            rzz(-5.98848712542991) q[1],q[2];
+            u3(0.56042125,-1.2880621,pi/2) q[1];
+            rzz(-6.64023274758061) q[0],q[1];
+            u3(0.56042125,-1.2431553,pi/2) q[2];
+            rzz(-6.6417912133385) q[0],q[2];
+            rx(-4.06512402388918) q[0];
+            rzz(-6.64059728943955) q[1],q[2];
+            rx(-4.06512402388918) q[1];
+            rx(-4.06512402388918) q[2];
+            barrier q[0],q[1],q[2];
+            measure q[0] -> meas[0];
+            measure q[1] -> meas[1];
+            measure q[2] -> meas[2];
+            barrier q[0],q[1],q[2];
+            measure q[0] -> meas0[0];
+            measure q[1] -> meas0[1];
+            measure q[2] -> meas0[2];
+            """
+        )
+        result = execute(circuit, self.backend).result()
+        counts = result.get_counts()
+        assert len(counts) == 8


### PR DESCRIPTION
- Add test to cover parameterized gates with two targets handed to the simulator via Qiskit